### PR TITLE
feat(cli): support Outlook calendar exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+Essential guidance for AI assistants working in this repository.
+
+This is the entry point for coding agents. Keep changes small, preserve the
+calendar analyzer's user-facing behavior, and validate with the local workflow.
+
+## Core Rules
+
+### Git Operations
+
+- Do not run `git add`, `git commit`, `git push`, `git tag`, or other commands
+  that modify version control state unless the user explicitly asks for that
+  exact action in the current turn.
+- Read-only git commands are fine when needed for context, but prefer
+  `git --no-pager ...` for readable output.
+- If files are already staged, do not assume the staging was intentional for
+  your current task. Ask before changing the index.
+
+### Code Editing
+
+- Use the agent patch editing mechanism for manual edits.
+- Do not use `sed`, `awk`, `perl`, shell redirection, or Python scripts to
+  modify repository files.
+- Keep edits scoped to the requested behavior and existing project style.
+- This is a single-file Python CLI with tests; avoid unnecessary abstraction.
+
+### Privacy And Output
+
+- Calendar data is local and can contain private meeting titles, attendees,
+  locations, and notes.
+- The default CLI intentionally prints the requested meeting-title summary,
+  including the top meeting titles. Do not remove or redact that behavior unless
+  the user explicitly asks.
+- Avoid debug-printing raw calendar records, CSV rows, XML appointments, or
+  unreviewed parsed structures. Route intentional user-facing output through
+  `generate_summary(...)`.
+- If CodeQL flags intentional title output, document the intent narrowly instead
+  of changing the product behavior around the scanner.
+
+## Validation Workflow
+
+Use the `justfile` recipes:
+
+```bash
+just check
+just ci
+just security
+just test
+just fix
+```
+
+Common direct checks:
+
+```bash
+uv run pytest
+uv run ruff format --check .
+uv run ruff check .
+uv run ty check calendar_analyzer.py tests --error all
+uv run semgrep --error --strict --timeout 30 --config semgrep.yaml .
+```
+
+Codex sandbox shells may not include Homebrew on `PATH`. When needed, prefer:
+
+```bash
+PATH=/opt/homebrew/bin:$PATH just check
+PATH=/opt/homebrew/bin:$PATH uv run pytest
+```
+
+## Project Context
+
+- Language: Python 3.11+
+- Package/dependency manager: `uv`
+- Workflow runner: `just`
+- Main module: `calendar_analyzer.py`
+- Tests: `tests/test_calendar_analyzer.py`
+- Security rules: `semgrep.yaml`, CodeQL workflow
+- Supported calendar inputs: Apple `.ics`, `.icbu`, `.sqlitedb`; Outlook `.olm`,
+  `.ics`, and `.csv`
+
+## Design Principles
+
+- Preserve the CLI contract documented in `README.md`.
+- Prefer explicit, user-facing errors over tracebacks for malformed calendar
+  inputs.
+- Keep calendar parsing tolerant across export variants, but validate enough to
+  avoid treating arbitrary files as calendars.
+- Keep security rules repository-specific. Do not duplicate broad CodeQL, Ruff,
+  or pip-audit coverage in Semgrep unless there is a clear project invariant.
+- Tests should cover user-visible behavior and parsing edge cases, especially
+  date handling, export formats, and privacy-sensitive output paths.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 [![codecov](https://codecov.io/github/acgetchell/calendar-analyzer/graph/badge.svg?token=UWRe2AcNnm)](https://codecov.io/github/acgetchell/calendar-analyzer)
 [![CodeQL Advanced](https://github.com/acgetchell/calendar-analyzer/actions/workflows/codeql.yml/badge.svg)](https://github.com/acgetchell/calendar-analyzer/actions/workflows/codeql.yml)
 
-A simple Python script that analyzes your Apple Calendar data and provides a summary of your meetings.
+A simple Python script that analyzes Apple Calendar and Outlook calendar exports and summarizes your meetings.
 
 ## Features
 
 - Analyzes calendar events from a specified date range (defaults to past year)
+- Reads Apple Calendar `.ics`, `.icbu`, and `.sqlitedb` exports
+- Reads Outlook for Mac `.olm` archives and Outlook `.ics` or `.csv` exports
 - Provides statistics on:
   - Total number of meetings
   - Total meeting hours
@@ -46,35 +48,49 @@ See [scripts/README.md](scripts/README.md) for script linting and formatting det
 
 ## Exporting Your Calendar
 
-1. Open the Calendar app on your Mac
-2. Select the calendar(s) you want to analyze
-3. Go to File > Export and save as `.ics` file to your Documents folder
-4. Run the analyzer:
+### Apple Calendar
 
-   ```bash
-   uv run calendar-analyzer --calendar ~/Documents/your-calendar.ics
-   ```
+1. Open Calendar on your Mac.
+2. Select the calendar you want to analyze.
+3. Choose File > Export > Export.
+4. Save the `.ics` file.
+
+### Outlook for Mac
+
+1. Open Outlook for Mac.
+2. Choose File > Export.
+3. Select Calendar in the export options. You can include other item types too; the analyzer reads the calendar items from the archive.
+4. Continue through the export wizard and save the Outlook for Mac archive (`.olm`) file.
+5. If Outlook asks whether to delete exported items, choose the option to keep them in Outlook.
+
+Outlook `.ics` and `.csv` calendar exports are also supported when available.
+
+Run the analyzer with the exported file:
+
+```bash
+just run --calendar ~/Documents/your-calendar.olm
+```
 
 ## Usage
 
 ```bash
 # Basic usage (analyzes past year)
-uv run calendar-analyzer
+just run
 
 # Analyze specific date range
-uv run calendar-analyzer --start-date 2024-01-01 --end-date 2024-03-31
+just run --start-date 2024-01-01 --end-date 2024-03-31
 
 # Analyze last 90 days
-uv run calendar-analyzer --days 90
+just run --days 90
 
 # Specify custom calendar file
-uv run calendar-analyzer --calendar /path/to/your/calendar.ics
+just run --calendar /path/to/your/calendar.olm
 
 # Show top 10 meeting titles
-uv run calendar-analyzer --titles 10
+just run --titles 10
 
 # Save results to file
-uv run calendar-analyzer --output analysis.txt
+just run --output analysis.txt
 ```
 
 The script automatically finds your most recent calendar file (unless specified), analyzes the date range, and displays or saves results.
@@ -89,7 +105,7 @@ Common recipes are listed alphabetically:
 # Run Ruff, Ty, typos, TOML checks, script checks, and tests
 just check
 
-# Run the full local CI workflow
+# Run local CI checks without generating coverage
 just ci
 
 # Generate coverage.xml and terminal coverage
@@ -97,6 +113,9 @@ just coverage
 
 # Apply Ruff, Taplo, and shell script auto-fixes
 just fix
+
+# Run the analyzer
+just run --days 90
 
 # Run pip-audit and repository Semgrep rules
 just security
@@ -108,7 +127,7 @@ just setup
 just test
 ```
 
-The local workflow mirrors CI: `just ci` runs all checks, security scans, and coverage.
+The local workflow mirrors CI: `just ci` runs all checks and security scans. Coverage is generated separately with `just coverage` and uploaded by the Codecov workflow.
 
 ### Dependency Management
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ just run --calendar /path/to/your/calendar.olm
 # Show top 10 meeting titles
 just run --titles 10
 
+# Show top 8 common meeting times
+just run --times 8
+
+# Exclude meeting titles by case-insensitive regex
+just run --exclude-title 'SVM|VMTH'
+
+# Repeat exclusions for separate title patterns
+just run --exclude-title 'SVM' --exclude-title 'VMTH|State of the Hospital'
+
 # Save results to file
 just run --output analysis.txt
 ```

--- a/calendar_analyzer.py
+++ b/calendar_analyzer.py
@@ -1,11 +1,13 @@
-"""Analyze Apple Calendar exports and summarize meeting patterns."""
+"""Analyze Apple and Outlook calendar exports and summarize meeting patterns."""
 
 from __future__ import annotations
 
 import argparse
+import csv
 import sqlite3
 import sys
 import tempfile
+import zipfile
 from contextlib import closing
 from datetime import UTC, date, datetime, time, timedelta
 from pathlib import Path
@@ -13,16 +15,25 @@ from typing import TYPE_CHECKING, Any, NoReturn, TypedDict
 from zoneinfo import ZoneInfo
 
 import pandas as pd
+from defusedxml import ElementTree
 from icalendar import Calendar
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterable
+    from xml.etree.ElementTree import Element
 
 PACIFIC = ZoneInfo("America/Los_Angeles")
 APPLE_EPOCH = datetime(2001, 1, 1, tzinfo=UTC)
-CALENDAR_PATTERNS = ("*.ics", "*.icbu", "*.sqlitedb")
+CALENDAR_PATTERNS = ("*.ics", "*.icbu", "*.sqlitedb", "*.olm")
 DEFAULT_DAYS_BACK = 365
 DEFAULT_DURATION_HOURS = 1.0
+OUTLOOK_DATE_FORMATS = ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y", "%d/%m/%Y", "%d/%m/%y")
+OUTLOOK_TIME_FORMATS = ("%I:%M %p", "%I:%M:%S %p", "%H:%M", "%H:%M:%S")
+OUTLOOK_DATETIME_FORMATS = (
+    *(f"{date_format} {time_format}" for date_format in OUTLOOK_DATE_FORMATS for time_format in OUTLOOK_TIME_FORMATS),
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+)
 
 
 class Meeting(TypedDict):
@@ -53,13 +64,13 @@ def convert_to_pacific(dt: datetime) -> datetime:
 
 def print_calendar_export_instructions() -> None:
     """Print instructions for exporting a calendar file."""
-    print("\nPlease export your calendar from the Calendar app:")
-    print("1. Open the Calendar app")
-    print("2. Select the calendar(s) you want to analyze")
-    print("3. Go to File > Export")
+    print("\nPlease export your calendar from Calendar or Outlook:")
+    print("1. Apple Calendar: select the calendar, then use File > Export")
+    print("2. Outlook for Mac: export an Outlook archive (.olm)")
+    print("3. Outlook can also be analyzed from exported ICS or CSV calendar files")
     print("4. Save the calendar file")
     print("\nThen run this script with the path to your exported file:")
-    print("uv run calendar-analyzer --calendar /path/to/your/calendar.ics")
+    print("just run --calendar /path/to/your/calendar.olm")
 
 
 def get_calendar_path(calendar_file: str | Path | None = None) -> Path:
@@ -87,6 +98,10 @@ def analyze_calendar(
     """Analyze calendar events from the specified date range."""
     if calendar_path.suffix.lower() == ".sqlitedb":
         return analyze_sqlite_calendar(calendar_path, start_date, end_date, days_back)
+    if calendar_path.suffix.lower() == ".olm":
+        return analyze_olm_calendar(calendar_path, start_date, end_date, days_back)
+    if calendar_path.suffix.lower() == ".csv":
+        return analyze_outlook_csv_calendar(calendar_path, start_date, end_date, days_back)
     if calendar_path.suffix.lower() == ".icbu":
         sqlite_db_path = calendar_path / "Calendar.sqlitedb"
         if sqlite_db_path.exists():
@@ -126,6 +141,47 @@ def analyze_sqlite_calendar(
         raise_system_exit()
 
     return _analyze_sqlite_rows(rows)
+
+
+def analyze_outlook_csv_calendar(
+    calendar_path: Path,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    days_back: int = DEFAULT_DAYS_BACK,
+) -> CalendarAnalysis:
+    """Analyze events from an Outlook CSV calendar export."""
+    start_date, end_date = _resolve_date_range(start_date, end_date, days_back)
+
+    try:
+        rows = _read_outlook_csv_rows(calendar_path)
+    except OSError as error:
+        print(f"Error reading Outlook CSV calendar: {error}")
+        raise_system_exit()
+    except ValueError as error:
+        print(f"Error parsing Outlook CSV calendar: {error}")
+        raise_system_exit()
+
+    return _analyze_outlook_csv_rows(rows, start_date, end_date)
+
+
+def analyze_olm_calendar(
+    calendar_path: Path,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    days_back: int = DEFAULT_DAYS_BACK,
+) -> CalendarAnalysis:
+    """Analyze calendar appointments from an Outlook for Mac OLM archive."""
+    start_date, end_date = _resolve_date_range(start_date, end_date, days_back)
+
+    try:
+        appointments = _read_olm_appointments(calendar_path)
+        return _analyze_olm_appointments(appointments, start_date, end_date)
+    except (OSError, zipfile.BadZipFile) as error:
+        print(f"Error reading OLM calendar: {error}")
+        raise_system_exit()
+    except ValueError as error:
+        print(f"Error parsing OLM calendar: {error}")
+        raise_system_exit()
 
 
 def generate_summary(meetings: list[Meeting], stats: MeetingStats, num_titles: int = 50) -> str:
@@ -433,6 +489,309 @@ def _analyze_sqlite_rows(rows: Iterable[tuple[str | None, int, int]]) -> Calenda
     return meetings, stats
 
 
+def _read_olm_appointments(calendar_path: Path) -> list[Element]:
+    """Read appointment XML entries from an Outlook for Mac OLM archive."""
+    appointments: list[Element] = []
+    calendar_entries = 0
+    with zipfile.ZipFile(calendar_path) as archive:
+        for name in sorted(archive.namelist()):
+            if not name.endswith("Calendar.xml"):
+                continue
+
+            calendar_entries += 1
+            try:
+                root = ElementTree.fromstring(archive.read(name))
+            except ElementTree.ParseError as error:
+                msg = f"{name} is not valid XML: {error}"
+                raise ValueError(msg) from error
+            appointments.extend(_olm_xml_appointments(root))
+
+    if calendar_entries == 0:
+        msg = "No Calendar.xml entries found in OLM archive."
+        raise ValueError(msg)
+    return appointments
+
+
+def _olm_xml_appointments(root: Element) -> list[Element]:
+    """Return appointment elements from an OLM Calendar.xml tree."""
+    return [element for element in root.iter() if _xml_local_name(element.tag) == "appointment"]
+
+
+def _analyze_olm_appointments(
+    appointments: Iterable[Element],
+    start_date: datetime,
+    end_date: datetime,
+) -> CalendarAnalysis:
+    """Normalize OLM appointment XML and aggregate meeting stats."""
+    meetings: list[Meeting] = []
+    stats = _empty_stats()
+    dated_appointments = 0
+    unparsable_start_values: list[str] = []
+
+    for appointment in appointments:
+        if _xml_truthy(_xml_text(appointment, ("OPFCalendarEventCopyIsAllDayEvent", "AllDayEvent"))):
+            continue
+
+        start_value = _olm_appointment_start_text(appointment)
+        if start_value is not None:
+            dated_appointments += 1
+
+        start = _olm_appointment_start(appointment)
+        if start is None:
+            if start_value is not None:
+                unparsable_start_values.append(start_value)
+            continue
+
+        start = convert_to_pacific(start)
+        if not start_date <= start <= end_date:
+            continue
+
+        end = _olm_appointment_end(appointment, start)
+        duration_hours = _positive_duration_hours(start, end)
+        meetings.append(
+            {
+                "date": start.date(),
+                "time": start.time(),
+                "summary": _xml_text(appointment, ("OPFCalendarEventCopySummary", "Subject", "Summary")) or "No Title",
+                "duration_hours": duration_hours,
+            }
+        )
+        _update_stats(stats, duration_hours)
+
+    if dated_appointments and dated_appointments == len(unparsable_start_values):
+        examples = ", ".join(unparsable_start_values[:3])
+        msg = f"Could not parse any OLM appointment start dates. Example value(s): {examples}"
+        raise ValueError(msg)
+
+    return meetings, stats
+
+
+def _olm_appointment_start(appointment: Element) -> datetime | None:
+    """Return the start datetime from an OLM appointment."""
+    return _outlook_datetime(_olm_appointment_start_text(appointment))
+
+
+def _olm_appointment_start_text(appointment: Element) -> str | None:
+    """Return the raw OLM appointment start value."""
+    return _xml_text(
+        appointment,
+        (
+            "OPFCalendarEventCopyStartTime",
+            "OPFCalendarEventCopyStartDate",
+            "StartTime",
+            "StartDate",
+        ),
+    )
+
+
+def _olm_appointment_end(appointment: Element, start: datetime) -> datetime:
+    """Return the end datetime from an OLM appointment."""
+    end = _outlook_datetime(
+        _xml_text(
+            appointment,
+            (
+                "OPFCalendarEventCopyEndTime",
+                "OPFCalendarEventCopyEndDate",
+                "EndTime",
+                "EndDate",
+            ),
+        )
+    )
+    return end or start + timedelta(hours=DEFAULT_DURATION_HOURS)
+
+
+def _xml_text(element: Element, field_names: tuple[str, ...]) -> str | None:
+    """Return text from the first matching descendant XML element."""
+    normalized_names = {_normalize_csv_field(field_name) for field_name in field_names}
+    for child in element.iter():
+        if _normalize_csv_field(_xml_local_name(child.tag)) not in normalized_names:
+            continue
+
+        text = "".join(child.itertext()).strip()
+        if text:
+            return text
+    return None
+
+
+def _xml_local_name(tag: str) -> str:
+    """Return an XML tag name without any namespace prefix."""
+    return tag.rsplit("}", maxsplit=1)[-1]
+
+
+def _xml_truthy(value: str | None) -> bool:
+    """Return whether an OLM XML boolean-ish value means true."""
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "y"}
+
+
+def _read_outlook_csv_rows(calendar_path: Path) -> list[dict[str, str]]:
+    """Read an Outlook CSV export and validate that it has usable date columns."""
+    with calendar_path.open(newline="", encoding="utf-8-sig") as calendar_file:
+        reader = csv.DictReader(calendar_file)
+        fieldnames = reader.fieldnames or []
+        _validate_outlook_csv_headers(fieldnames)
+        return [{key: value or "" for key, value in row.items() if key is not None} for row in reader]
+
+
+def _validate_outlook_csv_headers(fieldnames: Iterable[str]) -> None:
+    """Raise a user-facing error when a CSV file does not look like a calendar export."""
+    fields = list(fieldnames)
+    if not fields:
+        msg = "CSV header row is missing."
+        raise ValueError(msg)
+
+    has_split_start = _csv_has_field(fields, ("Start Date", "StartDate")) and _csv_has_field(
+        fields,
+        ("Start Time", "StartTime"),
+    )
+    has_combined_start = _csv_has_field(fields, ("Start", "Starts", "Start Date Time", "StartDateTime"))
+    if not has_split_start and not has_combined_start:
+        msg = "CSV must include Outlook start columns such as Start Date and Start Time, or a combined Start column."
+        raise ValueError(msg)
+
+
+def _analyze_outlook_csv_rows(
+    rows: Iterable[dict[str, str]],
+    start_date: datetime,
+    end_date: datetime,
+) -> CalendarAnalysis:
+    """Normalize Outlook CSV rows and aggregate meeting stats."""
+    meetings: list[Meeting] = []
+    stats = _empty_stats()
+
+    for row in rows:
+        start = _outlook_csv_start_datetime(row)
+        if start is None:
+            continue
+
+        start = convert_to_pacific(start)
+        if not start_date <= start <= end_date:
+            continue
+
+        end = _outlook_csv_end_datetime(row, start)
+        duration_hours = _positive_duration_hours(start, end)
+        meetings.append(
+            {
+                "date": start.date(),
+                "time": start.time(),
+                "summary": _csv_value(row, ("Subject", "Title", "Summary")) or "No Title",
+                "duration_hours": duration_hours,
+            }
+        )
+        _update_stats(stats, duration_hours)
+
+    return meetings, stats
+
+
+def _outlook_csv_start_datetime(row: dict[str, str]) -> datetime | None:
+    """Return the row start datetime, skipping all-day rows."""
+    if _csv_truthy(_csv_value(row, ("All day event", "All Day Event", "All Day", "AllDayEvent"))):
+        return None
+
+    return _outlook_split_datetime(row, ("Start Date", "StartDate"), ("Start Time", "StartTime")) or _outlook_datetime(
+        _csv_value(row, ("Start", "Starts", "Start Date Time", "StartDateTime"))
+    )
+
+
+def _outlook_csv_end_datetime(row: dict[str, str], start: datetime) -> datetime:
+    """Return the row end datetime, defaulting when Outlook omitted one."""
+    end = _outlook_split_datetime(
+        row,
+        ("End Date", "EndDate"),
+        ("End Time", "EndTime"),
+        fallback_date=start,
+    ) or _outlook_datetime(_csv_value(row, ("End", "Ends", "End Date Time", "EndDateTime")))
+
+    return end or start + timedelta(hours=DEFAULT_DURATION_HOURS)
+
+
+def _outlook_split_datetime(
+    row: dict[str, str],
+    date_aliases: tuple[str, ...],
+    time_aliases: tuple[str, ...],
+    fallback_date: datetime | None = None,
+) -> datetime | None:
+    """Parse Outlook date and time columns into a Pacific-aware datetime."""
+    date_value = _csv_value(row, date_aliases)
+    time_value = _csv_value(row, time_aliases)
+    if not date_value and fallback_date is None:
+        return None
+    if not date_value:
+        date_value = _fallback_date_text(fallback_date)
+    if not time_value:
+        time_value = "12:00 AM"
+
+    return _outlook_datetime(f"{date_value} {time_value}") or _outlook_datetime(date_value)
+
+
+def _fallback_date_text(fallback_date: datetime | None) -> str:
+    """Return a date string for the already-validated fallback date."""
+    if fallback_date is None:
+        msg = "Fallback date is required."
+        raise ValueError(msg)
+    return fallback_date.strftime("%Y-%m-%d")
+
+
+def _outlook_datetime(value: str | None) -> datetime | None:
+    """Parse a date/time value from an Outlook CSV export."""
+    if value is None or not value.strip():
+        return None
+
+    text = value.strip()
+    for date_format in OUTLOOK_DATETIME_FORMATS:
+        try:
+            return datetime.strptime(text, date_format).replace(tzinfo=PACIFIC)
+        except ValueError:
+            continue
+
+    for date_format in OUTLOOK_DATE_FORMATS:
+        try:
+            return datetime.strptime(text, date_format).replace(tzinfo=PACIFIC)
+        except ValueError:
+            continue
+
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=PACIFIC)
+    return convert_to_pacific(parsed)
+
+
+def _positive_duration_hours(start: datetime, end: datetime) -> float:
+    """Return a positive duration, falling back when end precedes start."""
+    duration_hours = (end - start).total_seconds() / 3600
+    if duration_hours <= 0:
+        return DEFAULT_DURATION_HOURS
+    return duration_hours
+
+
+def _csv_value(row: dict[str, str], aliases: tuple[str, ...]) -> str | None:
+    """Return a CSV value by case-insensitive, punctuation-insensitive field alias."""
+    normalized_aliases = {_normalize_csv_field(alias) for alias in aliases}
+    for field, raw_value in row.items():
+        if _normalize_csv_field(field) in normalized_aliases:
+            value = raw_value.strip()
+            return value or None
+    return None
+
+
+def _csv_has_field(fields: Iterable[str], aliases: tuple[str, ...]) -> bool:
+    """Return whether any CSV field matches one of the aliases."""
+    normalized_aliases = {_normalize_csv_field(alias) for alias in aliases}
+    return any(_normalize_csv_field(field) in normalized_aliases for field in fields)
+
+
+def _normalize_csv_field(value: str) -> str:
+    """Normalize CSV headers for tolerant matching across Outlook variants."""
+    return "".join(character for character in value.lower() if character.isalnum())
+
+
+def _csv_truthy(value: str | None) -> bool:
+    """Return whether an Outlook CSV boolean-ish cell means true."""
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "y"}
+
+
 def _empty_stats() -> MeetingStats:
     """Create an empty meeting statistics accumulator."""
     return {"total_meetings": 0, "total_hours": 0.0}
@@ -447,7 +806,7 @@ def _update_stats(stats: MeetingStats, duration_hours: float) -> None:
 def _parse_args() -> argparse.Namespace:
     """Parse command-line arguments for the calendar analyzer CLI."""
     parser = argparse.ArgumentParser(description="Analyze calendar events from a specified date range.")
-    parser.add_argument("--calendar", help="Path to the exported calendar file (.ics)")
+    parser.add_argument("--calendar", help="Path to the exported calendar file (.ics, .olm, .csv, .icbu, .sqlitedb)")
     parser.add_argument("--start-date", help="Start date for analysis (YYYY-MM-DD)")
     parser.add_argument("--end-date", help="End date for analysis (YYYY-MM-DD)")
     parser.add_argument(

--- a/calendar_analyzer.py
+++ b/calendar_analyzer.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import argparse
 import csv
+import re
 import sqlite3
 import sys
 import tempfile
 import zipfile
 from contextlib import closing
+from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, TypedDict
@@ -27,6 +29,7 @@ APPLE_EPOCH = datetime(2001, 1, 1, tzinfo=UTC)
 CALENDAR_PATTERNS = ("*.ics", "*.icbu", "*.sqlitedb", "*.olm")
 DEFAULT_DAYS_BACK = 365
 DEFAULT_DURATION_HOURS = 1.0
+MAX_TIMED_MEETING_HOURS = 8.0
 OUTLOOK_DATE_FORMATS = ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y", "%d/%m/%Y", "%d/%m/%y")
 OUTLOOK_TIME_FORMATS = ("%I:%M %p", "%I:%M:%S %p", "%H:%M", "%H:%M:%S")
 OUTLOOK_DATETIME_FORMATS = (
@@ -52,7 +55,18 @@ class MeetingStats(TypedDict):
     total_hours: float
 
 
+@dataclass(frozen=True)
+class SummaryOptions:
+    """Display options for the generated calendar summary."""
+
+    num_titles: int = 50
+    num_times: int = 5
+    period_start: datetime | None = None
+    period_end: datetime | None = None
+
+
 CalendarAnalysis = tuple[list[Meeting], MeetingStats]
+SqliteCalendarRow = tuple[str | None, int, int, Any]
 
 
 def convert_to_pacific(dt: datetime) -> datetime:
@@ -184,14 +198,19 @@ def analyze_olm_calendar(
         raise_system_exit()
 
 
-def generate_summary(meetings: list[Meeting], stats: MeetingStats, num_titles: int = 50) -> str:
+def generate_summary(
+    meetings: list[Meeting],
+    stats: MeetingStats,
+    options: SummaryOptions | None = None,
+) -> str:
     """Generate a summary of the calendar analysis."""
     if not meetings:
         return "No meetings found in the specified time period."
 
+    options = options or SummaryOptions()
     df = pd.DataFrame(meetings)
-    start_date = df["date"].min()
-    end_date = df["date"].max()
+    start_date = options.period_start.date() if options.period_start is not None else df["date"].min()
+    end_date = options.period_end.date() if options.period_end is not None else df["date"].max()
     date_range_days = max((end_date - start_date).days, 1)
     avg_meetings_per_day = stats["total_meetings"] / date_range_days
     avg_meeting_duration = stats["total_hours"] / stats["total_meetings"]
@@ -217,16 +236,16 @@ def generate_summary(meetings: list[Meeting], stats: MeetingStats, num_titles: i
         f"- Total Meeting Hours: {stats['total_hours']:.1f}",
         f"- Average Meetings per Day: {avg_meetings_per_day:.1f}",
         f"- Average Meeting Duration: {avg_meeting_duration:.1f} hours",
-        f"\nTop 5 Most Common Meeting Times ({timezone_name}):",
+        f"\nTop {options.num_times} Most Common Meeting Times ({timezone_name}):",
     ]
 
-    time_counts = df["time"].value_counts().head()
+    time_counts = df["time"].value_counts().head(options.num_times)
     summary.extend(
         f"- {meeting_time.strftime('%I:%M %p')}: {count} meetings" for meeting_time, count in time_counts.items()
     )
-    summary.extend([f"\nTop {num_titles} Most Frequent Meeting Titles:", "-" * 30])
+    summary.extend([f"\nTop {options.num_titles} Most Frequent Meeting Titles:", "-" * 30])
 
-    title_counts = df["summary"].value_counts().head(num_titles)
+    title_counts = df["summary"].value_counts().head(options.num_titles)
     for title, count in title_counts.items():
         display_title = f"{title[:100]}..." if len(title) > 100 else title
         summary.append(f"{count:4d} | {display_title}")
@@ -237,16 +256,28 @@ def generate_summary(meetings: list[Meeting], stats: MeetingStats, num_titles: i
 def main() -> None:
     """Run the calendar analyzer command-line interface."""
     args = _parse_args()
-    start_date = _parse_date_argument(args.start_date, "Start")
-    end_date = _parse_date_argument(args.end_date, "End")
-    _validate_date_range(start_date, end_date)
+    requested_start_date = _parse_date_argument(args.start_date, "Start")
+    requested_end_date = _parse_date_argument(args.end_date, "End")
+    _validate_date_range(requested_start_date, requested_end_date)
+    excluded_title_patterns = _compile_title_exclusion_patterns(args.exclude_titles)
+    start_date, end_date = _resolve_date_range(requested_start_date, requested_end_date, args.days)
 
     print("📊 Analyzing your calendar...")
     calendar_path = get_calendar_path(args.calendar)
     print(f"Found calendar at: {calendar_path}")
 
     meetings, stats = analyze_calendar(calendar_path, start_date, end_date, args.days)
-    summary = generate_summary(meetings, stats, args.titles)
+    meetings, stats = _exclude_title_matches(meetings, excluded_title_patterns)
+    summary = generate_summary(
+        meetings,
+        stats,
+        SummaryOptions(
+            num_titles=args.titles,
+            num_times=args.times,
+            period_start=start_date,
+            period_end=end_date,
+        ),
+    )
     _write_or_print_summary(summary, args.output)
 
 
@@ -375,15 +406,21 @@ def _analyze_ics_events(calendar: Calendar, start_date: datetime, end_date: date
     stats = _empty_stats()
 
     for event in calendar.walk("VEVENT"):
-        start = _event_start_datetime(event)
-        if start is None:
+        if _event_is_transparent(event):
             continue
 
-        start = convert_to_pacific(start)
+        raw_start = _event_start_datetime(event)
+        if raw_start is None:
+            continue
+
+        start = convert_to_pacific(raw_start)
         if not start_date <= start <= end_date:
             continue
 
         duration_hours = _event_duration_hours(event, start)
+        if _is_all_day_like_calendar_block(start, duration_hours) or _is_floating_midnight(raw_start):
+            continue
+
         meeting = _meeting_from_event(event, start, duration_hours)
         meetings.append(meeting)
         _update_stats(stats, duration_hours)
@@ -397,6 +434,12 @@ def _event_start_datetime(event: Any) -> datetime | None:
     if start is None or not isinstance(start.dt, datetime):
         return None
     return start.dt
+
+
+def _event_is_transparent(event: Any) -> bool:
+    """Return whether a VEVENT is marked free/transparent."""
+    transparency = event.get("transp")
+    return str(transparency or "").strip().upper() == "TRANSPARENT"
 
 
 def _event_duration_hours(event: Any, start: datetime) -> float:
@@ -449,33 +492,56 @@ def _fetch_sqlite_calendar_rows(
     calendar_path: Path,
     start_seconds: int,
     end_seconds: int,
-) -> list[tuple[str | None, int, int]]:
+) -> list[SqliteCalendarRow]:
     """Fetch SQLite calendar rows in the Apple-epoch date range."""
     with closing(sqlite3.connect(calendar_path)) as conn:
         cursor = conn.cursor()
-        cursor.execute(
-            """
+        all_day_column = _sqlite_all_day_column(cursor)
+        all_day_expression = _quote_sqlite_identifier(all_day_column) if all_day_column is not None else "0"
+        # The only interpolated SQL is a column name returned by PRAGMA table_info.
+        query = f"""
             SELECT
                 summary,
                 start_date,
-                end_date
+                end_date,
+                {all_day_expression}
             FROM CalendarItem
             WHERE start_date >= ? AND start_date <= ?
-            """,
-            (start_seconds, end_seconds),
-        )
+            """  # noqa: S608
+        cursor.execute(query, (start_seconds, end_seconds))
         return cursor.fetchall()
 
 
-def _analyze_sqlite_rows(rows: Iterable[tuple[str | None, int, int]]) -> CalendarAnalysis:
+def _sqlite_all_day_column(cursor: sqlite3.Cursor) -> str | None:
+    """Return the CalendarItem all-day column name when the schema has one."""
+    cursor.execute("PRAGMA table_info(CalendarItem)")
+    for column in cursor.fetchall():
+        column_name = str(column[1])
+        if _normalize_csv_field(column_name) in {"allday", "isallday"}:
+            return column_name
+    return None
+
+
+def _quote_sqlite_identifier(identifier: str) -> str:
+    """Quote a SQLite identifier that came from SQLite schema introspection."""
+    return f'"{identifier.replace(chr(34), chr(34) * 2)}"'
+
+
+def _analyze_sqlite_rows(rows: Iterable[SqliteCalendarRow]) -> CalendarAnalysis:
     """Normalize SQLite calendar rows and aggregate meeting stats."""
     meetings: list[Meeting] = []
     stats = _empty_stats()
 
-    for summary, start_seconds, end_seconds in rows:
+    for summary, start_seconds, end_seconds, is_all_day in rows:
+        if _csv_truthy(str(is_all_day)):
+            continue
+
         start_dt = convert_to_pacific(APPLE_EPOCH + timedelta(seconds=start_seconds))
         end_dt = convert_to_pacific(APPLE_EPOCH + timedelta(seconds=end_seconds))
-        duration_hours = (end_dt - start_dt).total_seconds() / 3600
+        duration_hours = _positive_duration_hours(start_dt, end_dt)
+        if _is_all_day_like_calendar_block(start_dt, duration_hours):
+            continue
+
         meetings.append(
             {
                 "date": start_dt.date(),
@@ -529,7 +595,7 @@ def _analyze_olm_appointments(
     unparsable_start_values: list[str] = []
 
     for appointment in appointments:
-        if _xml_truthy(_xml_text(appointment, ("OPFCalendarEventCopyIsAllDayEvent", "AllDayEvent"))):
+        if _olm_appointment_is_all_day(appointment) or _olm_appointment_is_free(appointment):
             continue
 
         start_value = _olm_appointment_start_text(appointment)
@@ -548,6 +614,9 @@ def _analyze_olm_appointments(
 
         end = _olm_appointment_end(appointment, start)
         duration_hours = _positive_duration_hours(start, end)
+        if _is_all_day_like_calendar_block(start, duration_hours):
+            continue
+
         meetings.append(
             {
                 "date": start.date(),
@@ -568,7 +637,12 @@ def _analyze_olm_appointments(
 
 def _olm_appointment_start(appointment: Element) -> datetime | None:
     """Return the start datetime from an OLM appointment."""
-    return _outlook_datetime(_olm_appointment_start_text(appointment))
+    start = _outlook_datetime(_olm_appointment_start_text(appointment), require_time=True)
+    return start or _outlook_xml_split_datetime(
+        appointment,
+        ("OPFCalendarEventCopyStartDate", "StartDate"),
+        ("OPFCalendarEventCopyStartTime", "StartTime"),
+    )
 
 
 def _olm_appointment_start_text(appointment: Element) -> str | None:
@@ -577,27 +651,54 @@ def _olm_appointment_start_text(appointment: Element) -> str | None:
         appointment,
         (
             "OPFCalendarEventCopyStartTime",
-            "OPFCalendarEventCopyStartDate",
             "StartTime",
-            "StartDate",
         ),
     )
 
 
-def _olm_appointment_end(appointment: Element, start: datetime) -> datetime:
-    """Return the end datetime from an OLM appointment."""
-    end = _outlook_datetime(
+def _olm_appointment_is_all_day(appointment: Element) -> bool:
+    """Return whether an OLM appointment is explicitly or implicitly all-day."""
+    if _xml_truthy(
         _xml_text(
             appointment,
             (
-                "OPFCalendarEventCopyEndTime",
-                "OPFCalendarEventCopyEndDate",
-                "EndTime",
-                "EndDate",
+                "OPFCalendarEventGetIsAllDayEvent",
+                "OPFCalendarEventCopyIsAllDayEvent",
+                "OPFCalendarEventCopyAllDayEvent",
+                "AllDayEvent",
+                "AllDay",
             ),
         )
+    ):
+        return True
+
+    return _olm_appointment_start_text(appointment) is None and _olm_appointment_date_text(appointment) is not None
+
+
+def _olm_appointment_is_free(appointment: Element) -> bool:
+    """Return whether an OLM appointment is marked free on the calendar."""
+    return _is_free_busy_free(_xml_text(appointment, ("OPFCalendarEventCopyFreeBusyStatus", "FreeBusyStatus")))
+
+
+def _olm_appointment_date_text(appointment: Element) -> str | None:
+    """Return the raw OLM appointment date-only value."""
+    return _xml_text(appointment, ("OPFCalendarEventCopyStartDate", "StartDate"))
+
+
+def _olm_appointment_end(appointment: Element, start: datetime) -> datetime:
+    """Return the end datetime from an OLM appointment."""
+    end = _outlook_datetime(_olm_appointment_end_text(appointment)) or _outlook_xml_split_datetime(
+        appointment,
+        ("OPFCalendarEventCopyEndDate", "EndDate"),
+        ("OPFCalendarEventCopyEndTime", "EndTime"),
+        fallback_date=start,
     )
     return end or start + timedelta(hours=DEFAULT_DURATION_HOURS)
+
+
+def _olm_appointment_end_text(appointment: Element) -> str | None:
+    """Return the raw OLM appointment end value."""
+    return _xml_text(appointment, ("OPFCalendarEventCopyEndTime", "EndTime"))
 
 
 def _xml_text(element: Element, field_names: tuple[str, ...]) -> str | None:
@@ -669,6 +770,9 @@ def _analyze_outlook_csv_rows(
 
         end = _outlook_csv_end_datetime(row, start)
         duration_hours = _positive_duration_hours(start, end)
+        if _is_all_day_like_calendar_block(start, duration_hours):
+            continue
+
         meetings.append(
             {
                 "date": start.date(),
@@ -686,9 +790,12 @@ def _outlook_csv_start_datetime(row: dict[str, str]) -> datetime | None:
     """Return the row start datetime, skipping all-day rows."""
     if _csv_truthy(_csv_value(row, ("All day event", "All Day Event", "All Day", "AllDayEvent"))):
         return None
+    if _is_free_busy_free(_csv_value(row, ("Show Time As", "Show As", "Busy Status", "FreeBusyStatus"))):
+        return None
 
     return _outlook_split_datetime(row, ("Start Date", "StartDate"), ("Start Time", "StartTime")) or _outlook_datetime(
-        _csv_value(row, ("Start", "Starts", "Start Date Time", "StartDateTime"))
+        _csv_value(row, ("Start", "Starts", "Start Date Time", "StartDateTime")),
+        require_time=True,
     )
 
 
@@ -711,16 +818,45 @@ def _outlook_split_datetime(
     fallback_date: datetime | None = None,
 ) -> datetime | None:
     """Parse Outlook date and time columns into a Pacific-aware datetime."""
-    date_value = _csv_value(row, date_aliases)
-    time_value = _csv_value(row, time_aliases)
+    return _outlook_datetime_from_parts(_csv_value(row, date_aliases), _csv_value(row, time_aliases), fallback_date)
+
+
+def _outlook_xml_split_datetime(
+    element: Element,
+    date_aliases: tuple[str, ...],
+    time_aliases: tuple[str, ...],
+    fallback_date: datetime | None = None,
+) -> datetime | None:
+    """Parse Outlook XML date and time fields into a Pacific-aware datetime."""
+    return _outlook_datetime_from_parts(
+        _xml_text(element, date_aliases),
+        _xml_text(element, time_aliases),
+        fallback_date,
+    )
+
+
+def _outlook_datetime_from_parts(
+    date_value: str | None,
+    time_value: str | None,
+    fallback_date: datetime | None = None,
+) -> datetime | None:
+    """Parse date and time parts, treating missing start times as all-day."""
     if not date_value and fallback_date is None:
         return None
+    if not time_value and fallback_date is None:
+        return None
+    has_explicit_time = bool(time_value)
     if not date_value:
         date_value = _fallback_date_text(fallback_date)
     if not time_value:
         time_value = "12:00 AM"
 
-    return _outlook_datetime(f"{date_value} {time_value}") or _outlook_datetime(date_value)
+    parsed = _outlook_datetime(f"{date_value} {time_value}")
+    if parsed is not None:
+        return parsed
+    if has_explicit_time:
+        return None
+    return _outlook_datetime(date_value)
 
 
 def _fallback_date_text(fallback_date: datetime | None) -> str:
@@ -731,24 +867,38 @@ def _fallback_date_text(fallback_date: datetime | None) -> str:
     return fallback_date.strftime("%Y-%m-%d")
 
 
-def _outlook_datetime(value: str | None) -> datetime | None:
+def _outlook_datetime(value: str | None, *, require_time: bool = False) -> datetime | None:
     """Parse a date/time value from an Outlook CSV export."""
     if value is None or not value.strip():
         return None
 
     text = value.strip()
-    for date_format in OUTLOOK_DATETIME_FORMATS:
+    parsed = _parse_outlook_strptime(text, OUTLOOK_DATETIME_FORMATS)
+    if parsed is not None:
+        return parsed
+
+    if not require_time:
+        parsed = _parse_outlook_strptime(text, OUTLOOK_DATE_FORMATS)
+        if parsed is not None:
+            return parsed
+    elif not _outlook_text_has_time(text):
+        return None
+
+    return _parse_outlook_iso_datetime(text)
+
+
+def _parse_outlook_strptime(text: str, date_formats: tuple[str, ...]) -> datetime | None:
+    """Parse an Outlook date/time string using known strptime formats."""
+    for date_format in date_formats:
         try:
             return datetime.strptime(text, date_format).replace(tzinfo=PACIFIC)
         except ValueError:
             continue
+    return None
 
-    for date_format in OUTLOOK_DATE_FORMATS:
-        try:
-            return datetime.strptime(text, date_format).replace(tzinfo=PACIFIC)
-        except ValueError:
-            continue
 
+def _parse_outlook_iso_datetime(text: str) -> datetime | None:
+    """Parse an ISO datetime while preserving or assigning Pacific time."""
     try:
         parsed = datetime.fromisoformat(text)
     except ValueError:
@@ -758,12 +908,33 @@ def _outlook_datetime(value: str | None) -> datetime | None:
     return convert_to_pacific(parsed)
 
 
+def _outlook_text_has_time(text: str) -> bool:
+    """Return whether an Outlook date/time string appears to include a time."""
+    return ":" in text or "T" in text
+
+
 def _positive_duration_hours(start: datetime, end: datetime) -> float:
     """Return a positive duration, falling back when end precedes start."""
     duration_hours = (end - start).total_seconds() / 3600
     if duration_hours <= 0:
         return DEFAULT_DURATION_HOURS
     return duration_hours
+
+
+def _is_all_day_like_calendar_block(start: datetime, duration_hours: float) -> bool:
+    """Return whether a timed export row looks like an all-day/non-meeting block."""
+    starts_at_midnight = _starts_at_midnight(start)
+    return starts_at_midnight or duration_hours >= MAX_TIMED_MEETING_HOURS
+
+
+def _is_floating_midnight(start: datetime) -> bool:
+    """Return whether an ICS floating local start time is midnight."""
+    return start.tzinfo is None and _starts_at_midnight(start)
+
+
+def _starts_at_midnight(start: datetime) -> bool:
+    """Return whether a datetime starts exactly at midnight."""
+    return start.timetz().replace(tzinfo=None) == time()
 
 
 def _csv_value(row: dict[str, str], aliases: tuple[str, ...]) -> str | None:
@@ -792,9 +963,50 @@ def _csv_truthy(value: str | None) -> bool:
     return value is not None and value.strip().lower() in {"1", "true", "yes", "y"}
 
 
+def _is_free_busy_free(value: str | None) -> bool:
+    """Return whether a free/busy value marks the item as free time."""
+    return value is not None and value.strip().lower() in {"0", "free", "transparent"}
+
+
 def _empty_stats() -> MeetingStats:
     """Create an empty meeting statistics accumulator."""
     return {"total_meetings": 0, "total_hours": 0.0}
+
+
+def _compile_title_exclusion_patterns(patterns: list[str] | None) -> list[re.Pattern[str]]:
+    """Compile case-insensitive title exclusion regexes."""
+    compiled_patterns: list[re.Pattern[str]] = []
+    for pattern in patterns or []:
+        try:
+            compiled_patterns.append(re.compile(pattern, re.IGNORECASE))
+        except re.error as error:
+            print(f"Error: Invalid --exclude-title regex {pattern!r}: {error}")
+            raise_system_exit()
+    return compiled_patterns
+
+
+def _exclude_title_matches(
+    meetings: list[Meeting],
+    excluded_title_patterns: list[re.Pattern[str]],
+) -> CalendarAnalysis:
+    """Remove meetings whose titles match any excluded title regex."""
+    if not excluded_title_patterns:
+        return meetings, _stats_from_meetings(meetings)
+
+    filtered_meetings = [
+        meeting
+        for meeting in meetings
+        if not any(pattern.search(meeting["summary"]) for pattern in excluded_title_patterns)
+    ]
+    return filtered_meetings, _stats_from_meetings(filtered_meetings)
+
+
+def _stats_from_meetings(meetings: list[Meeting]) -> MeetingStats:
+    """Build aggregate statistics from normalized meetings."""
+    return {
+        "total_meetings": len(meetings),
+        "total_hours": sum(meeting["duration_hours"] for meeting in meetings),
+    }
 
 
 def _update_stats(stats: MeetingStats, duration_hours: float) -> None:
@@ -815,7 +1027,14 @@ def _parse_args() -> argparse.Namespace:
         default=DEFAULT_DAYS_BACK,
         help=f"Number of days to look back from end date (default: {DEFAULT_DAYS_BACK})",
     )
+    parser.add_argument("--times", type=int, default=5, help="Number of meeting times to display (default: 5)")
     parser.add_argument("--titles", type=int, default=50, help="Number of meeting titles to display (default: 50)")
+    parser.add_argument(
+        "--exclude-title",
+        action="append",
+        dest="exclude_titles",
+        help="Case-insensitive regex for meeting titles to exclude from statistics; may be repeated",
+    )
     parser.add_argument("--output", help="Path to save the analysis summary (default: print to console)")
     return parser.parse_args()
 
@@ -846,6 +1065,8 @@ def _validate_date_range(start_date: datetime | None, end_date: datetime | None)
 def _write_or_print_summary(summary: str, output: str | None) -> None:
     """Write the summary to a file or print it when no output path is supplied."""
     if output is None:
+        # The CLI intentionally prints the requested meeting-title report by default.
+        # codeql[py/clear-text-logging-sensitive-data]  # noqa: ERA001
         print("\n" + summary)
         return
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch:
+      default:
+        target: 90%

--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ _ensure-uv:
 check: lint test
     @echo "Checks complete."
 
-ci: check security coverage
+ci: check security
     @echo "CI checks complete."
 
 coverage: _ensure-uv
@@ -47,9 +47,10 @@ fix: python-fix toml-fix script-fmt
 help-workflows:
     @echo "Common workflows:"
     @echo "  just check         # Run lint, type checks, spelling, TOML checks, script checks, and tests"
-    @echo "  just ci            # Run the full local CI workflow"
+    @echo "  just ci            # Run local CI checks without generating coverage"
     @echo "  just coverage      # Generate coverage.xml and terminal coverage"
     @echo "  just fix           # Apply Ruff, Taplo, and shell script auto-fixes"
+    @echo "  just run [args]    # Run the calendar analyzer"
     @echo "  just security      # Run pip-audit and repository Semgrep rules"
     @echo "  just setup         # Sync uv dev dependencies"
     @echo "  just test          # Run tests only"
@@ -97,6 +98,9 @@ security: pip-audit semgrep
 
 semgrep: _ensure-uv
     uv run semgrep --error --strict --timeout 30 --config semgrep.yaml .
+
+run *args: _ensure-uv
+    uv run calendar-analyzer {{args}}
 
 setup: python-sync
     @echo "Setup complete."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 description = "A Python script that analyzes your Apple Calendar data and provides a summary of your meetings"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["icalendar>=6.3.1", "pandas>=2.3.0"]
+dependencies = ["defusedxml>=0.7.1", "icalendar>=6.3.1", "pandas>=2.3.0"]
 
 [project.scripts]
 calendar-analyzer = "calendar_analyzer:main"

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -113,6 +113,23 @@ rules:
       with sqlite3.connect(...) as $CONN:
           ...
 
+  - id: calendar-analyzer.python.no-raw-calendar-record-debug-print
+    languages:
+      - python
+    severity: ERROR
+    message: "Do not debug-print raw calendar records or title fields; route intentional user-facing output through generate_summary(...)."
+    metadata:
+      category: security
+      cwe:
+        - "CWE-532: Insertion of Sensitive Information into Log File"
+      rationale: "Raw calendar records can contain private meeting titles, attendees, locations, and notes."
+    paths:
+      include:
+        - "/calendar_analyzer.py"
+    patterns:
+      - pattern-regex: >-
+          ^\s*print\(\s*(?:meeting|meetings|row|rows|appointment|appointments)(?:\s*\[\s*["'](?:summary|Subject)["']\s*\])?\s*\)
+
   - id: calendar-analyzer.python.no-broad-exception
     languages:
       - python

--- a/tests/test_calendar_analyzer.py
+++ b/tests/test_calendar_analyzer.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import tempfile
 import textwrap
+import zipfile
 from contextlib import closing
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -32,6 +33,15 @@ def create_temp_ics_file(content: str, suffix: str = ".ics") -> str:
         tmp.write(content)
         tmp.flush()
         return tmp.name
+
+
+def create_temp_olm_file(calendar_xml: str) -> str:
+    """Helper function to create a temporary OLM-like archive with Calendar.xml."""
+    with tempfile.NamedTemporaryFile(suffix=".olm", delete=False) as tmp:
+        tmp_path = tmp.name
+    with zipfile.ZipFile(tmp_path, "w") as archive:
+        archive.writestr("Accounts/Calendar.xml", calendar_xml)
+    return tmp_path
 
 
 def create_temp_dummy_file(suffix: str = ".ics") -> str:
@@ -242,10 +252,11 @@ def test_print_calendar_export_instructions(capsys) -> None:
     calendar_analyzer.print_calendar_export_instructions()
 
     out = capsys.readouterr().out
-    assert "Please export your calendar from the Calendar app:" in out
-    assert "Open the Calendar app" in out
-    assert "File > Export" in out
-    assert "uv run calendar-analyzer --calendar" in out
+    assert "Please export your calendar from Calendar or Outlook:" in out
+    assert "Apple Calendar: select the calendar, then use File > Export" in out
+    assert "Outlook for Mac: export an Outlook archive (.olm)" in out
+    assert "Outlook can also be analyzed from exported ICS or CSV calendar files" in out
+    assert "just run --calendar" in out
 
 
 def test_generate_summary_no_meetings() -> None:
@@ -611,6 +622,25 @@ def test_get_calendar_path_auto_discovery_with_files(mock_home, capsys) -> None:
 
 
 @patch("pathlib.Path.home")
+def test_get_calendar_path_auto_discovery_ignores_csv_files(mock_home, capsys) -> None:
+    """Test auto-discovery ignores generic CSV files unless explicitly requested."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        home_path = Path(tmp_dir)
+        mock_home.return_value = home_path
+        documents_dir = home_path / "Documents"
+        documents_dir.mkdir()
+        (documents_dir / "not-a-calendar.csv").write_text("Amount,Description\n1.00,Coffee\n")
+
+        with pytest.raises(SystemExit) as exc_info:
+            calendar_analyzer.get_calendar_path()
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗ No calendar files found" in out
+        assert "not-a-calendar.csv" not in out
+
+
+@patch("pathlib.Path.home")
 def test_get_calendar_path_auto_discovery_no_files(mock_home, capsys) -> None:
     """Test auto-discovery when no calendar files are found."""
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -629,7 +659,7 @@ def test_get_calendar_path_auto_discovery_no_files(mock_home, capsys) -> None:
         assert "Searching for calendar files in:" in out
         assert "✗ No calendar files found" in out
         assert "Error: No calendar files found in any of the expected locations." in out
-        assert "Please export your calendar from the Calendar app:" in out
+        assert "Please export your calendar from Calendar or Outlook:" in out
 
 
 @patch("pathlib.Path.home")
@@ -668,21 +698,23 @@ def test_get_calendar_path_auto_discovery_multiple_file_types(mock_home, capsys)
         ics_file = documents_dir / "calendar.ics"
         icbu_file = library_dir / "backup.icbu"
         sqlite_file = library_dir / "calendar.sqlitedb"
+        olm_file = documents_dir / "calendar.olm"
 
         ics_file.write_text("ics content")
         icbu_file.write_text("icbu content")
         sqlite_file.write_text("sqlite content")
+        olm_file.write_text("olm content")
 
         result = calendar_analyzer.get_calendar_path()
 
         # Should find one of the files (the most recent one)
         assert result.exists()
-        assert result.suffix in [".ics", ".icbu", ".sqlitedb"]
+        assert result.suffix in [".ics", ".icbu", ".sqlitedb", ".olm"]
 
         out = capsys.readouterr().out
         # The function prints found files per directory, not total
         assert "✓ Found 2 calendar files" in out  # Library/Calendars
-        assert "✓ Found 1 calendar files" in out  # Documents
+        assert "✓ Found 2 calendar files" in out  # Documents
 
 
 @patch("pathlib.Path.home")
@@ -812,6 +844,141 @@ def test_analyze_calendar_with_sqlite_file_honors_days_back() -> None:
 
         assert meetings == []
         assert stats == {"total_meetings": 0, "total_hours": 0.0}
+
+
+def test_analyze_calendar_with_olm_file() -> None:
+    """Test direct Outlook for Mac OLM calendar analysis through analyze_calendar."""
+    calendar_xml = textwrap.dedent("""
+    <appointments>
+      <appointment>
+        <OPFCalendarEventCopySummary>Outlook Mac Meeting</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartTime>2023-07-01T17:00:00Z</OPFCalendarEventCopyStartTime>
+        <OPFCalendarEventCopyEndTime>2023-07-01T18:30:00Z</OPFCalendarEventCopyEndTime>
+      </appointment>
+      <appointment>
+        <OPFCalendarEventCopySummary>Outlook All Day</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartTime>2023-07-01T00:00:00Z</OPFCalendarEventCopyStartTime>
+        <OPFCalendarEventCopyIsAllDayEvent>true</OPFCalendarEventCopyIsAllDayEvent>
+      </appointment>
+    </appointments>
+    """)
+    tmp_path = create_temp_olm_file(calendar_xml)
+
+    try:
+        meetings, stats = calendar_analyzer.analyze_calendar(
+            Path(tmp_path),
+            datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
+        )
+    finally:
+        Path(tmp_path).unlink()
+
+    assert stats == {"total_meetings": 1, "total_hours": 1.5}
+    assert meetings[0]["summary"] == "Outlook Mac Meeting"
+    assert meetings[0]["time"].hour == 10
+
+
+def test_analyze_olm_calendar_defaults_missing_end_and_summary() -> None:
+    """Test OLM calendar analysis defaults optional appointment fields."""
+    calendar_xml = textwrap.dedent("""
+    <appointments>
+      <appointment>
+        <OPFCalendarEventCopyStartTime>2023-07-01T10:00:00</OPFCalendarEventCopyStartTime>
+      </appointment>
+    </appointments>
+    """)
+    tmp_path = create_temp_olm_file(calendar_xml)
+
+    try:
+        meetings, stats = calendar_analyzer.analyze_olm_calendar(
+            Path(tmp_path),
+            datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
+        )
+    finally:
+        Path(tmp_path).unlink()
+
+    assert stats == {"total_meetings": 1, "total_hours": 1.0}
+    assert meetings[0]["summary"] == "No Title"
+
+
+def test_analyze_olm_calendar_without_calendar_xml(capsys) -> None:
+    """Test OLM calendar analysis reports archives without Calendar.xml."""
+    with tempfile.NamedTemporaryFile(suffix=".olm", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    with zipfile.ZipFile(tmp_path, "w") as archive:
+        archive.writestr("Accounts/Mail.xml", "<emails />")
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            calendar_analyzer.analyze_olm_calendar(Path(tmp_path))
+    finally:
+        tmp_path.unlink()
+
+    assert exc_info.value.code == 1
+    assert "Error parsing OLM calendar: No Calendar.xml entries found in OLM archive." in capsys.readouterr().out
+
+
+def test_analyze_olm_calendar_bad_archive(capsys) -> None:
+    """Test OLM calendar analysis reports unreadable OLM archives."""
+    with tempfile.NamedTemporaryFile(suffix=".olm", delete=False) as tmp:
+        tmp.write(b"not a zip archive")
+        tmp_path = Path(tmp.name)
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            calendar_analyzer.analyze_olm_calendar(Path(tmp_path))
+    finally:
+        tmp_path.unlink()
+
+    assert exc_info.value.code == 1
+    assert "Error reading OLM calendar:" in capsys.readouterr().out
+
+
+def test_analyze_olm_calendar_errors_when_no_start_dates_parse(capsys) -> None:
+    """Test OLM calendar analysis reports unsupported date formats."""
+    calendar_xml = textwrap.dedent("""
+    <appointments>
+      <appointment>
+        <OPFCalendarEventCopySummary>Broken Date</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartTime>not-a-date</OPFCalendarEventCopyStartTime>
+      </appointment>
+    </appointments>
+    """)
+    tmp_path = create_temp_olm_file(calendar_xml)
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            calendar_analyzer.analyze_olm_calendar(Path(tmp_path))
+    finally:
+        Path(tmp_path).unlink()
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error parsing OLM calendar: Could not parse any OLM appointment start dates." in out
+    assert "not-a-date" in out
+
+
+def test_analyze_calendar_with_explicit_outlook_csv_file() -> None:
+    """Test explicit Outlook CSV calendar analysis remains supported."""
+    with tempfile.NamedTemporaryFile(suffix=".csv", mode="w", encoding="utf-8", newline="", delete=False) as tmp:
+        tmp.write("Subject,Start Date,Start Time,End Date,End Time,All day event\n")
+        tmp.write("CSV Meeting,07/01/2023,10:00 AM,07/01/2023,11:30 AM,False\n")
+        tmp.write("CSV All Day,07/01/2023,12:00 AM,07/01/2023,11:59 PM,True\n")
+        tmp_path = Path(tmp.name)
+
+    try:
+        meetings, stats = calendar_analyzer.analyze_calendar(
+            tmp_path,
+            datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
+        )
+    finally:
+        tmp_path.unlink()
+
+    assert stats == {"total_meetings": 1, "total_hours": 1.5}
+    assert meetings[0]["summary"] == "CSV Meeting"
+    assert meetings[0]["time"].hour == 10
 
 
 def test_analyze_sqlite_calendar_defaults_missing_summary() -> None:

--- a/tests/test_calendar_analyzer.py
+++ b/tests/test_calendar_analyzer.py
@@ -108,6 +108,82 @@ def test_analyze_mock_ics(monkeypatch, capsys) -> None:
     assert "Total Meeting Hours: 3.0" in out
 
 
+def test_main_excludes_titles_by_regex(monkeypatch, capsys, tmp_path: Path) -> None:
+    """Test title exclusion regexes remove matching meetings from stats and output."""
+    calendar_path = tmp_path / "calendar.ics"
+    calendar_path.write_text(
+        textwrap.dedent("""
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        BEGIN:VEVENT
+        DTSTART:20230701T100000Z
+        DURATION:PT1H
+        SUMMARY:SVM Town Hall
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTART:20230701T120000Z
+        DURATION:PT1H
+        SUMMARY:All VMTH Meeting
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTART:20230701T140000Z
+        DURATION:PT1H
+        SUMMARY:Project Sync
+        END:VEVENT
+        END:VCALENDAR
+        """),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "calendar-analyzer",
+            "--calendar",
+            str(calendar_path),
+            "--start-date",
+            "2023-06-30",
+            "--end-date",
+            "2023-07-03",
+            "--exclude-title",
+            "svm",
+            "--exclude-title",
+            "VMTH|State of the Hospital",
+        ],
+    )
+
+    calendar_analyzer.main()
+
+    out = capsys.readouterr().out
+    assert "Project Sync" in out
+    assert "SVM Town Hall" not in out
+    assert "All VMTH Meeting" not in out
+    assert "Total Meetings: 1" in out
+    assert "Total Meeting Hours: 1.0" in out
+
+
+def test_main_invalid_exclude_title_regex_exits(monkeypatch, capsys, tmp_path: Path) -> None:
+    """Test invalid title exclusion regexes fail before analysis."""
+    calendar_path = tmp_path / "calendar.ics"
+    calendar_path.write_text("BEGIN:VCALENDAR\nEND:VCALENDAR\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "calendar-analyzer",
+            "--calendar",
+            str(calendar_path),
+            "--exclude-title",
+            "[",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.main()
+
+    assert exc_info.value.code == 1
+    assert "Error: Invalid --exclude-title regex '[':" in capsys.readouterr().out
+
+
 def test_invalid_start_date_format(monkeypatch, capsys) -> None:
     """Test that invalid start date format causes system exit."""
     # Create a temporary dummy file path (secure alternative to mktemp)
@@ -474,13 +550,85 @@ def test_generate_summary_with_long_titles() -> None:
 
     stats: calendar_analyzer.MeetingStats = {"total_meetings": 2, "total_hours": 2.0}
 
-    result = calendar_analyzer.generate_summary(meetings, stats, 5)
+    result = calendar_analyzer.generate_summary(meetings, stats, calendar_analyzer.SummaryOptions(num_titles=5))
 
     # Long title should be truncated
     assert "A" * 100 + "..." in result
     assert "Short title" in result
     assert "Total Meetings: 2" in result
     assert "Average Meetings per Day: 1.0" in result
+
+
+def test_generate_summary_limits_common_times_and_titles() -> None:
+    """Test summary uses requested limits for common times and titles."""
+    meetings: list[calendar_analyzer.Meeting] = [
+        {
+            "date": datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC).date(),
+            "time": datetime(2023, 7, 1, 9, 0, tzinfo=calendar_analyzer.PACIFIC).time(),
+            "summary": "Frequent",
+            "duration_hours": 1.0,
+        },
+        {
+            "date": datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC).date(),
+            "time": datetime(2023, 7, 1, 9, 0, tzinfo=calendar_analyzer.PACIFIC).time(),
+            "summary": "Frequent",
+            "duration_hours": 1.0,
+        },
+        {
+            "date": datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC).date(),
+            "time": datetime(2023, 7, 1, 10, 0, tzinfo=calendar_analyzer.PACIFIC).time(),
+            "summary": "Second",
+            "duration_hours": 1.0,
+        },
+        {
+            "date": datetime(2023, 7, 3, tzinfo=calendar_analyzer.PACIFIC).date(),
+            "time": datetime(2023, 7, 1, 11, 0, tzinfo=calendar_analyzer.PACIFIC).time(),
+            "summary": "Third",
+            "duration_hours": 1.0,
+        },
+    ]
+    stats: calendar_analyzer.MeetingStats = {"total_meetings": 4, "total_hours": 4.0}
+
+    result = calendar_analyzer.generate_summary(
+        meetings,
+        stats,
+        calendar_analyzer.SummaryOptions(num_titles=2, num_times=1),
+    )
+
+    assert "Top 1 Most Common Meeting Times" in result
+    assert "- 09:00 AM: 2 meetings" in result
+    assert "- 10:00 AM: 1 meetings" not in result
+    assert "Top 2 Most Frequent Meeting Titles" in result
+    assert "Frequent" in result
+    assert "Second" in result
+    assert "Third" not in result
+
+
+def test_generate_summary_uses_requested_period_for_average() -> None:
+    """Test summary averages use the requested period rather than meeting spread."""
+    meetings: list[calendar_analyzer.Meeting] = [
+        {
+            "date": datetime(2023, 7, 5, tzinfo=calendar_analyzer.PACIFIC).date(),
+            "time": datetime(2023, 7, 5, 10, 0, tzinfo=calendar_analyzer.PACIFIC).time(),
+            "summary": "Middle Meeting",
+            "duration_hours": 1.0,
+        }
+    ]
+    stats: calendar_analyzer.MeetingStats = {"total_meetings": 1, "total_hours": 1.0}
+
+    result = calendar_analyzer.generate_summary(
+        meetings,
+        stats,
+        calendar_analyzer.SummaryOptions(
+            period_start=datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            period_end=datetime(2023, 7, 11, tzinfo=calendar_analyzer.PACIFIC),
+        ),
+    )
+
+    assert "- From: July 01, 2023" in result
+    assert "- To:   July 11, 2023" in result
+    assert "- Span: 10 days" in result
+    assert "- Average Meetings per Day: 0.1" in result
 
 
 def test_analyze_calendar_date_filtering() -> None:
@@ -520,6 +668,54 @@ def test_analyze_calendar_date_filtering() -> None:
 
     # Clean up
     Path(tmp_path).unlink()
+
+
+def test_analyze_calendar_skips_ics_all_day_events(tmp_path: Path) -> None:
+    """Test ICS all-day-like events are excluded as calendar blocks."""
+    calendar_path = tmp_path / "calendar.ics"
+    calendar_path.write_text(
+        textwrap.dedent("""
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        BEGIN:VEVENT
+        DTSTART;VALUE=DATE:20230701
+        DTEND;VALUE=DATE:20230702
+        SUMMARY:ICS All Day Event
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTART:20230701T160000Z
+        DTEND:20230701T170000Z
+        TRANSP:TRANSPARENT
+        SUMMARY:Free Calendar Hold
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTART:20230702T000000
+        DURATION:PT1H
+        SUMMARY:Midnight Export Block
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTART:20230703T090000
+        DURATION:PT8H
+        SUMMARY:Workday Block
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTART:20230701T170000Z
+        DTEND:20230701T180000Z
+        SUMMARY:ICS Timed Meeting
+        END:VEVENT
+        END:VCALENDAR
+        """),
+        encoding="utf-8",
+    )
+
+    meetings, stats = calendar_analyzer.analyze_calendar(
+        calendar_path,
+        datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+        datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
+    )
+
+    assert stats == {"total_meetings": 1, "total_hours": 1.0}
+    assert [meeting["summary"] for meeting in meetings] == ["ICS Timed Meeting"]
 
 
 def test_get_calendar_path_with_specified_file(capsys) -> None:
@@ -713,8 +909,7 @@ def test_get_calendar_path_auto_discovery_multiple_file_types(mock_home, capsys)
 
         out = capsys.readouterr().out
         # The function prints found files per directory, not total
-        assert "✓ Found 2 calendar files" in out  # Library/Calendars
-        assert "✓ Found 2 calendar files" in out  # Documents
+        assert out.count("✓ Found 2 calendar files") == 2
 
 
 @patch("pathlib.Path.home")
@@ -846,6 +1041,64 @@ def test_analyze_calendar_with_sqlite_file_honors_days_back() -> None:
         assert stats == {"total_meetings": 0, "total_hours": 0.0}
 
 
+def test_analyze_sqlite_calendar_skips_all_day_rows() -> None:
+    """Test SQLite calendar analysis excludes all-day-like rows."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        sqlite_path = Path(tmp_dir) / "calendar.sqlitedb"
+        meeting_start = datetime(2023, 7, 1, 17, 0, tzinfo=UTC)
+        meeting_end = datetime(2023, 7, 1, 18, 0, tzinfo=UTC)
+        all_day_start = datetime(2023, 7, 1, 7, 0, tzinfo=UTC)
+        all_day_end = datetime(2023, 7, 2, 7, 0, tzinfo=UTC)
+        midnight_start = datetime(2023, 7, 2, 7, 0, tzinfo=UTC)
+        midnight_end = datetime(2023, 7, 2, 8, 0, tzinfo=UTC)
+        workday_start = datetime(2023, 7, 3, 16, 0, tzinfo=UTC)
+        workday_end = datetime(2023, 7, 4, 0, 0, tzinfo=UTC)
+
+        with closing(sqlite3.connect(sqlite_path)) as conn:
+            conn.execute(
+                "CREATE TABLE CalendarItem (summary TEXT, start_date INTEGER, end_date INTEGER, all_day INTEGER)"
+            )
+            conn.executemany(
+                "INSERT INTO CalendarItem (summary, start_date, end_date, all_day) VALUES (?, ?, ?, ?)",
+                [
+                    (
+                        "Timed Meeting",
+                        int((meeting_start - calendar_analyzer.APPLE_EPOCH).total_seconds()),
+                        int((meeting_end - calendar_analyzer.APPLE_EPOCH).total_seconds()),
+                        0,
+                    ),
+                    (
+                        "All Day Event",
+                        int((all_day_start - calendar_analyzer.APPLE_EPOCH).total_seconds()),
+                        int((all_day_end - calendar_analyzer.APPLE_EPOCH).total_seconds()),
+                        1,
+                    ),
+                    (
+                        "Midnight Export Block",
+                        int((midnight_start - calendar_analyzer.APPLE_EPOCH).total_seconds()),
+                        int((midnight_end - calendar_analyzer.APPLE_EPOCH).total_seconds()),
+                        0,
+                    ),
+                    (
+                        "Workday Block",
+                        int((workday_start - calendar_analyzer.APPLE_EPOCH).total_seconds()),
+                        int((workday_end - calendar_analyzer.APPLE_EPOCH).total_seconds()),
+                        0,
+                    ),
+                ],
+            )
+            conn.commit()
+
+        meetings, stats = calendar_analyzer.analyze_sqlite_calendar(
+            sqlite_path,
+            datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
+        )
+
+        assert stats == {"total_meetings": 1, "total_hours": 1.0}
+        assert [meeting["summary"] for meeting in meetings] == ["Timed Meeting"]
+
+
 def test_analyze_calendar_with_olm_file() -> None:
     """Test direct Outlook for Mac OLM calendar analysis through analyze_calendar."""
     calendar_xml = textwrap.dedent("""
@@ -902,6 +1155,93 @@ def test_analyze_olm_calendar_defaults_missing_end_and_summary() -> None:
     assert meetings[0]["summary"] == "No Title"
 
 
+def test_analyze_olm_calendar_filters_requested_range() -> None:
+    """Test OLM calendar analysis only includes appointments in the requested range."""
+    calendar_xml = textwrap.dedent("""
+    <appointments>
+      <appointment>
+        <OPFCalendarEventCopySummary>Before Range</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartTime>2023-06-30T17:00:00Z</OPFCalendarEventCopyStartTime>
+        <OPFCalendarEventCopyEndTime>2023-06-30T18:00:00Z</OPFCalendarEventCopyEndTime>
+      </appointment>
+      <appointment>
+        <OPFCalendarEventCopySummary>In Range</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartTime>2023-07-03T17:00:00Z</OPFCalendarEventCopyStartTime>
+        <OPFCalendarEventCopyEndTime>2023-07-03T18:00:00Z</OPFCalendarEventCopyEndTime>
+      </appointment>
+    </appointments>
+    """)
+    tmp_path = create_temp_olm_file(calendar_xml)
+
+    try:
+        meetings, stats = calendar_analyzer.analyze_olm_calendar(
+            Path(tmp_path),
+            datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            datetime(2023, 7, 4, tzinfo=calendar_analyzer.PACIFIC),
+        )
+    finally:
+        Path(tmp_path).unlink()
+
+    assert stats == {"total_meetings": 1, "total_hours": 1.0}
+    assert [meeting["summary"] for meeting in meetings] == ["In Range"]
+
+
+def test_analyze_olm_calendar_skips_all_day_and_date_only_appointments() -> None:
+    """Test OLM analysis excludes all-day-like appointments."""
+    calendar_xml = textwrap.dedent("""
+    <appointments>
+      <appointment>
+        <OPFCalendarEventCopySummary>Split Timed Meeting</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartDate>2023-07-01</OPFCalendarEventCopyStartDate>
+        <OPFCalendarEventCopyStartTime>10:00 AM</OPFCalendarEventCopyStartTime>
+        <OPFCalendarEventCopyEndDate>2023-07-01</OPFCalendarEventCopyEndDate>
+        <OPFCalendarEventCopyEndTime>11:00 AM</OPFCalendarEventCopyEndTime>
+      </appointment>
+      <appointment>
+        <OPFCalendarEventCopySummary>Date Only Event</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartDate>2023-07-01</OPFCalendarEventCopyStartDate>
+      </appointment>
+      <appointment>
+        <OPFCalendarEventCopySummary>Explicit All Day Event</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartDate>2023-07-01</OPFCalendarEventCopyStartDate>
+        <OPFCalendarEventGetIsAllDayEvent>1</OPFCalendarEventGetIsAllDayEvent>
+      </appointment>
+      <appointment>
+        <OPFCalendarEventCopySummary>Free Calendar Hold</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartTime>2023-07-01T12:00:00</OPFCalendarEventCopyStartTime>
+        <OPFCalendarEventCopyEndTime>2023-07-01T13:00:00</OPFCalendarEventCopyEndTime>
+        <OPFCalendarEventCopyFreeBusyStatus>0</OPFCalendarEventCopyFreeBusyStatus>
+      </appointment>
+      <appointment>
+        <OPFCalendarEventCopySummary>Midnight Export Block</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartTime>2023-07-02T00:00:00</OPFCalendarEventCopyStartTime>
+        <OPFCalendarEventCopyEndTime>2023-07-02T01:00:00</OPFCalendarEventCopyEndTime>
+      </appointment>
+      <appointment>
+        <OPFCalendarEventCopySummary>Workday Block</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartDate>2023-07-03</OPFCalendarEventCopyStartDate>
+        <OPFCalendarEventCopyStartTime>9:00 AM</OPFCalendarEventCopyStartTime>
+        <OPFCalendarEventCopyEndDate>2023-07-03</OPFCalendarEventCopyEndDate>
+        <OPFCalendarEventCopyEndTime>5:00 PM</OPFCalendarEventCopyEndTime>
+      </appointment>
+    </appointments>
+    """)
+    tmp_path = create_temp_olm_file(calendar_xml)
+
+    try:
+        meetings, stats = calendar_analyzer.analyze_olm_calendar(
+            Path(tmp_path),
+            datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
+        )
+    finally:
+        Path(tmp_path).unlink()
+
+    assert stats == {"total_meetings": 1, "total_hours": 1.0}
+    assert [meeting["summary"] for meeting in meetings] == ["Split Timed Meeting"]
+    assert meetings[0]["time"].hour == 10
+
+
 def test_analyze_olm_calendar_without_calendar_xml(capsys) -> None:
     """Test OLM calendar analysis reports archives without Calendar.xml."""
     with tempfile.NamedTemporaryFile(suffix=".olm", delete=False) as tmp:
@@ -935,6 +1275,24 @@ def test_analyze_olm_calendar_bad_archive(capsys) -> None:
     assert "Error reading OLM calendar:" in capsys.readouterr().out
 
 
+def test_analyze_olm_calendar_bad_xml(capsys) -> None:
+    """Test OLM calendar analysis reports malformed Calendar.xml content."""
+    with tempfile.NamedTemporaryFile(suffix=".olm", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    with zipfile.ZipFile(tmp_path, "w") as archive:
+        archive.writestr("Accounts/Calendar.xml", "<appointments><appointment></appointments>")
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            calendar_analyzer.analyze_olm_calendar(Path(tmp_path))
+    finally:
+        tmp_path.unlink()
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error parsing OLM calendar: Accounts/Calendar.xml is not valid XML:" in out
+
+
 def test_analyze_olm_calendar_errors_when_no_start_dates_parse(capsys) -> None:
     """Test OLM calendar analysis reports unsupported date formats."""
     calendar_xml = textwrap.dedent("""
@@ -959,6 +1317,31 @@ def test_analyze_olm_calendar_errors_when_no_start_dates_parse(capsys) -> None:
     assert "not-a-date" in out
 
 
+def test_analyze_olm_calendar_errors_when_split_start_time_invalid(capsys) -> None:
+    """Test split OLM dates with invalid times are not mistaken for all-day events."""
+    calendar_xml = textwrap.dedent("""
+    <appointments>
+      <appointment>
+        <OPFCalendarEventCopySummary>Broken Split Date</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartDate>2023-07-01</OPFCalendarEventCopyStartDate>
+        <OPFCalendarEventCopyStartTime>not-a-time</OPFCalendarEventCopyStartTime>
+      </appointment>
+    </appointments>
+    """)
+    tmp_path = create_temp_olm_file(calendar_xml)
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            calendar_analyzer.analyze_olm_calendar(Path(tmp_path))
+    finally:
+        Path(tmp_path).unlink()
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error parsing OLM calendar: Could not parse any OLM appointment start dates." in out
+    assert "not-a-time" in out
+
+
 def test_analyze_calendar_with_explicit_outlook_csv_file() -> None:
     """Test explicit Outlook CSV calendar analysis remains supported."""
     with tempfile.NamedTemporaryFile(suffix=".csv", mode="w", encoding="utf-8", newline="", delete=False) as tmp:
@@ -979,6 +1362,110 @@ def test_analyze_calendar_with_explicit_outlook_csv_file() -> None:
     assert stats == {"total_meetings": 1, "total_hours": 1.5}
     assert meetings[0]["summary"] == "CSV Meeting"
     assert meetings[0]["time"].hour == 10
+
+
+def test_analyze_outlook_csv_calendar_read_error(capsys, tmp_path: Path) -> None:
+    """Test Outlook CSV analysis reports unreadable files."""
+    missing_path = tmp_path / "missing.csv"
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.analyze_outlook_csv_calendar(missing_path)
+
+    assert exc_info.value.code == 1
+    assert "Error reading Outlook CSV calendar:" in capsys.readouterr().out
+
+
+def test_analyze_outlook_csv_calendar_requires_header(capsys, tmp_path: Path) -> None:
+    """Test Outlook CSV analysis reports an empty CSV file."""
+    csv_path = tmp_path / "empty.csv"
+    csv_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.analyze_outlook_csv_calendar(csv_path)
+
+    assert exc_info.value.code == 1
+    assert "Error parsing Outlook CSV calendar: CSV header row is missing." in capsys.readouterr().out
+
+
+def test_analyze_outlook_csv_calendar_requires_start_columns(capsys, tmp_path: Path) -> None:
+    """Test Outlook CSV analysis rejects non-calendar CSV files."""
+    csv_path = tmp_path / "not-calendar.csv"
+    csv_path.write_text("Amount,Description\n1.00,Coffee\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.analyze_outlook_csv_calendar(csv_path)
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error parsing Outlook CSV calendar:" in out
+    assert "CSV must include Outlook start columns" in out
+
+
+def test_analyze_outlook_csv_calendar_filters_requested_range(tmp_path: Path) -> None:
+    """Test Outlook CSV analysis only includes rows in the requested range."""
+    csv_path = tmp_path / "calendar.csv"
+    csv_path.write_text(
+        textwrap.dedent("""\
+        Subject,Start Date,Start Time,End Date,End Time
+        Before Range,06/30/2023,10:00 AM,06/30/2023,11:00 AM
+        In Range,07/03/2023,10:00 AM,07/03/2023,11:00 AM
+        """),
+        encoding="utf-8",
+    )
+
+    meetings, stats = calendar_analyzer.analyze_outlook_csv_calendar(
+        csv_path,
+        datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+        datetime(2023, 7, 4, tzinfo=calendar_analyzer.PACIFIC),
+    )
+
+    assert stats == {"total_meetings": 1, "total_hours": 1.0}
+    assert [meeting["summary"] for meeting in meetings] == ["In Range"]
+
+
+def test_analyze_outlook_csv_calendar_skips_date_only_rows() -> None:
+    """Test Outlook CSV all-day-like rows are excluded."""
+    with tempfile.NamedTemporaryFile(suffix=".csv", mode="w", encoding="utf-8", newline="", delete=False) as tmp:
+        tmp.write("Subject,Start Date,Start Time,End Date,End Time,Show Time As\n")
+        tmp.write("CSV Timed Meeting,07/01/2023,10:00 AM,07/01/2023,11:00 AM,Busy\n")
+        tmp.write("CSV Date Only Event,07/01/2023,,07/01/2023,,Busy\n")
+        tmp.write("CSV Free Hold,07/01/2023,12:00 PM,07/01/2023,1:00 PM,Free\n")
+        tmp.write("CSV Midnight Export Block,07/02/2023,12:00 AM,07/02/2023,1:00 AM,Busy\n")
+        tmp.write("CSV Workday Block,07/03/2023,9:00 AM,07/03/2023,5:00 PM,Busy\n")
+        tmp_path = Path(tmp.name)
+
+    try:
+        meetings, stats = calendar_analyzer.analyze_outlook_csv_calendar(
+            tmp_path,
+            datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
+        )
+    finally:
+        tmp_path.unlink()
+
+    assert stats == {"total_meetings": 1, "total_hours": 1.0}
+    assert [meeting["summary"] for meeting in meetings] == ["CSV Timed Meeting"]
+
+
+def test_analyze_outlook_csv_calendar_skips_combined_date_only_start() -> None:
+    """Test combined Outlook Start columns need a time component."""
+    with tempfile.NamedTemporaryFile(suffix=".csv", mode="w", encoding="utf-8", newline="", delete=False) as tmp:
+        tmp.write("Subject,Start,End\n")
+        tmp.write("CSV Combined Timed,2023-07-01 10:00:00,2023-07-01 11:00:00\n")
+        tmp.write("CSV Combined Date Only,2023-07-01,2023-07-01\n")
+        tmp_path = Path(tmp.name)
+
+    try:
+        meetings, stats = calendar_analyzer.analyze_outlook_csv_calendar(
+            tmp_path,
+            datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
+        )
+    finally:
+        tmp_path.unlink()
+
+    assert stats == {"total_meetings": 1, "total_hours": 1.0}
+    assert [meeting["summary"] for meeting in meetings] == ["CSV Combined Timed"]
 
 
 def test_analyze_sqlite_calendar_defaults_missing_summary() -> None:
@@ -1250,13 +1737,13 @@ def test_analyze_calendar_duration_parsing_edge_cases() -> None:
         datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
     )
 
-    # Should process all events, with fallback durations where needed
-    assert stats["total_meetings"] == 3
+    # Should process timed meetings, with fallback durations where needed
+    assert stats["total_meetings"] == 2
 
     # Find each meeting and check duration handling
     meeting_summaries = [m["summary"] for m in meetings]
     assert "30 Minute Meeting" in meeting_summaries
-    assert "All Day Event with Duration" in meeting_summaries
+    assert "All Day Event with Duration" not in meeting_summaries
     assert "Invalid Duration Meeting" in meeting_summaries
 
     # Clean up

--- a/typos.toml
+++ b/typos.toml
@@ -14,6 +14,7 @@ extend-exclude = [
 
 [default.extend-words]
 ICAL = "ICAL"
+OPF = "OPF"
 VEVENT = "VEVENT"
 dtstart = "dtstart"
 sqlitedb = "sqlitedb"

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,7 @@ name = "calendar-analyzer"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "defusedxml" },
     { name = "icalendar" },
     { name = "pandas" },
 ]
@@ -104,6 +105,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "icalendar", specifier = ">=6.3.1" },
     { name = "pandas", specifier = ">=2.3.0" },
 ]


### PR DESCRIPTION
- Add Outlook for Mac OLM archive parsing for calendar appointments
- Support explicit Outlook CSV calendar exports without auto-discovering generic CSV files
- Route analyzer usage through `just run` and keep local CI coverage generation separate
- Document Apple Calendar and Outlook for Mac export workflows