### PR TITLE
feat(cli): generate paste-ready calendar prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![codecov](https://codecov.io/github/acgetchell/calendar-analyzer/graph/badge.svg?token=UWRe2AcNnm)](https://codecov.io/github/acgetchell/calendar-analyzer)
 [![CodeQL Advanced](https://github.com/acgetchell/calendar-analyzer/actions/workflows/codeql.yml/badge.svg)](https://github.com/acgetchell/calendar-analyzer/actions/workflows/codeql.yml)
 
-A simple Python script that analyzes Apple Calendar and Outlook calendar exports and summarizes your meetings.
+A small local script that analyzes Apple Calendar and Outlook calendar exports and summarizes your meetings.
 
 ## Features
 
 - Analyzes calendar events from a specified date range (defaults to past year)
 - Reads Apple Calendar `.ics`, `.icbu`, and `.sqlitedb` exports
-- Reads Outlook for Mac `.olm` archives and Outlook `.ics` or `.csv` exports
+- Reads Microsoft Outlook for Mac `.olm` archives and Outlook `.ics` or `.csv` exports
 - Does not read Outlook `.PST` files by design; use `.ics` for calendar-only exports
 - Saves normalized meeting data as a Polars-readable Parquet cache for faster repeated reports
 - Provides statistics on:
@@ -22,10 +22,205 @@ A simple Python script that analyzes Apple Calendar and Outlook calendar exports
   - Most common meeting times
   - Most frequent meeting titles
 
-## Prerequisites
+## Quick Start
 
-This project uses `uv` for Python dependencies and `just` for local workflows. The setup scripts install or verify
-the required tools, including script linters, and sync development dependencies.
+Install or verify `uv`, then install the analyzer command from this repository:
+
+```bash
+uv tool install .
+```
+
+Export a calendar file, then run:
+
+```bash
+calendar-analyzer --calendar ~/Documents/your-calendar.ics
+```
+
+## AI Analysis And Privacy
+
+Calendar Analyzer runs locally on your machine. It reads your exported calendar file, writes a local Parquet cache for
+faster follow-up reports, and does not send your calendar data to external servers.
+
+If you want AI help summarizing a week, understanding how your meeting time was spent, or drafting year-end
+accomplishment bullets from your calendar summary, generate a paste-ready prompt file and review it before sharing it
+with ChatGPT, Claude, or another AI tool:
+
+```bash
+calendar-analyzer --start-date 2025-05-01 --end-date 2026-04-30 --generate-prompt
+```
+
+The prompt can include private meeting titles because the default summary intentionally reports your most frequent
+meeting titles. It is currently based on meeting titles, dates, times, and durations; meeting notes, locations, and
+attendees are not imported. Run the analyzer once with `--calendar` first so the local Parquet cache exists. By default,
+the prompt is saved to `calendar-prompt.txt`.
+
+## Exporting Your Calendar
+
+### Apple Calendar
+
+1. Open Calendar on your Mac.
+2. Select the calendar you want to analyze.
+3. Choose File > Export > Export.
+4. Save the `.ics` file.
+
+### Microsoft Outlook for Mac
+
+1. Open Microsoft Outlook for Mac.
+2. Choose File > Export.
+3. Select Calendar in the export options. You can include other item types too; the analyzer reads the calendar items from the archive.
+4. Continue through the export wizard and save the Microsoft Outlook for Mac archive (`.olm`) file.
+5. If Outlook asks whether to delete exported items, choose the option to keep them in Outlook.
+
+### Microsoft Outlook for Windows
+
+Export the calendar as an `.ics` file:
+
+1. Open Microsoft Outlook for Windows and switch to Calendar.
+2. Select the calendar you want to analyze.
+3. Use File > Save Calendar, or the calendar sharing/export option available in your Outlook version.
+4. Choose an `.ics` calendar file and save it somewhere easy to find, such as Documents.
+
+Do not export a `.PST` file for this tool. The analyzer intentionally does not read PST files because a PST export can
+include mail, contacts, tasks, and other mailbox data, not just calendar information. Use an `.ics` calendar export
+instead.
+
+Outlook `.csv` calendar exports are also supported when available. CSV files are only imported when you pass
+them explicitly with `--calendar` because generic CSV files are common in Documents and Downloads.
+
+Run the analyzer with the exported file:
+
+```bash
+calendar-analyzer --calendar ~/Documents/your-calendar.ics
+```
+
+On Windows PowerShell:
+
+```powershell
+calendar-analyzer --calendar "$HOME\Documents\your-calendar.ics"
+```
+
+After the first import, the analyzer saves a Parquet cache. Later reports, including AI prompts, read from that cache
+instead of re-importing the calendar export, so they run faster.
+
+## Usage
+
+```bash
+# Basic usage (analyzes past year)
+calendar-analyzer
+
+# Analyze specific date range
+calendar-analyzer --start-date 2024-01-01 --end-date 2024-03-31
+
+# Analyze last 90 days
+calendar-analyzer --days 90
+
+# Specify custom calendar file
+calendar-analyzer --calendar /path/to/your/calendar.olm
+
+# Force re-importing the newest discovered calendar and refreshing the default cache
+calendar-analyzer --import
+
+# Force re-importing a specific calendar and refreshing its default cache
+calendar-analyzer --calendar /path/to/your/calendar.olm --import
+
+# Force re-importing a specific calendar into a specific saved cache
+calendar-analyzer \
+  --calendar "/path/to/your/calendar.ics" \
+  --dataframe ~/.cache/calendar-analyzer/meetings.parquet \
+  --import
+
+# Use a specific saved Polars/Parquet data file
+calendar-analyzer --dataframe /path/to/meetings.parquet
+
+# Show top 10 meeting titles
+calendar-analyzer --titles 10
+
+# Show top 8 common meeting times
+calendar-analyzer --times 8
+
+# Exclude meeting titles by case-insensitive regex
+calendar-analyzer --exclude-title 'SVM|VMTH'
+
+# Repeat exclusions for separate title patterns
+calendar-analyzer --exclude-title 'SVM' --exclude-title 'VMTH|State of the Hospital'
+
+# Save results to file
+calendar-analyzer --output analysis.txt
+
+# Save a paste-ready AI analysis prompt for ChatGPT or Claude
+calendar-analyzer --start-date 2024-01-01 --end-date 2024-01-07 --generate-prompt
+```
+
+The script looks for saved Polars/Parquet meeting data first, analyzes the requested date range from that data when
+available, and imports a calendar export when the saved data is missing or stale. By default, the cache is
+`~/.cache/calendar-analyzer/meetings.parquet`.
+
+Use `--import` when you want to ignore the existing saved Polars/Parquet file and rebuild it from the calendar export.
+Without `--calendar`, `--import` discovers the newest supported calendar export and refreshes the default cache. With
+`--calendar`, it imports that specific file. Add `--dataframe` when you want the refreshed cache written to a specific
+Parquet path.
+
+On Windows, the default cache without `--calendar` is stored under
+`%LOCALAPPDATA%\calendar-analyzer\meetings.parquet`. Reports show both the imported data coverage and the requested query
+date range so you can tell whether an empty or small result came from the query window or from the calendar export
+itself.
+
+## Installation
+
+### To Run Reports
+
+Minimum setup:
+
+- `uv`
+- This repository checkout
+- A supported calendar export file
+
+Install the analyzer as a local command:
+
+```bash
+uv tool install .
+```
+
+Then run:
+
+```bash
+calendar-analyzer --calendar /path/to/your/calendar.ics
+```
+
+`uv tool install .` reads `pyproject.toml`, uses Python 3.11 or newer, and installs the runtime packages needed by the
+analyzer. If `uv` says the tool directory is not on your `PATH`, run `uv tool update-shell`, restart your shell, and try
+`calendar-analyzer --help`.
+
+For a one-off run without installing the command, use:
+
+```bash
+uv run --no-dev calendar-analyzer --calendar /path/to/your/calendar.ics
+```
+
+`just` is not needed for running reports. It is part of the development workflow below.
+
+### To Develop
+
+Development uses `uv` for Python dependencies and `just` for local workflows. Install `just` with `uv`, then let the
+repository recipe install or verify the rest of the development tools and sync development dependencies:
+
+```bash
+uv tool install rust-just
+just setup
+```
+
+Run the local CI checks when setup finishes:
+
+```bash
+just ci
+```
+
+If `uv` says the tool directory is not on your `PATH`, run `uv tool update-shell`, restart your shell, and try
+`just --version`.
+
+The platform setup scripts are still available as all-in-one bootstraps. They install or verify `uv`, `just`, linters,
+script checkers, security scanners, and development dependencies. On Windows, the setup script also installs Git for
+Windows so the Bash-backed `just` recipes work from PowerShell.
 
 ```bash
 # macOS
@@ -38,123 +233,8 @@ Set-ExecutionPolicy -Scope Process Bypass
 .\scripts\setup-windows.ps1
 ```
 
-Both scripts run `just ci` by default. Use `--no-check` on macOS or `-NoCheck` on Windows to only install/sync dependencies.
-See [scripts/README.md](scripts/README.md) for script linting and formatting details.
-
-## Setup
-
-1. **Run the platform setup script above**
-2. **For later dependency refreshes:**
-
-   ```bash
-   just setup
-   ```
-
-## Exporting Your Calendar
-
-### Apple Calendar
-
-1. Open Calendar on your Mac.
-2. Select the calendar you want to analyze.
-3. Choose File > Export > Export.
-4. Save the `.ics` file.
-
-### Outlook for Mac
-
-1. Open Outlook for Mac.
-2. Choose File > Export.
-3. Select Calendar in the export options. You can include other item types too; the analyzer reads the calendar items from the archive.
-4. Continue through the export wizard and save the Outlook for Mac archive (`.olm`) file.
-5. If Outlook asks whether to delete exported items, choose the option to keep them in Outlook.
-
-Outlook `.ics` and `.csv` calendar exports are also supported when available. CSV files are only imported when you pass
-them explicitly with `--calendar` because generic CSV files are common in Documents and Downloads.
-
-### Outlook for Windows
-
-Export the calendar as an `.ics` file:
-
-1. Open Outlook and switch to Calendar.
-2. Select the calendar you want to analyze.
-3. Use File > Save Calendar, or the calendar sharing/export option available in your Outlook version.
-4. Choose an `.ics` calendar file and save it somewhere easy to find, such as Documents.
-
-Do not export a `.PST` file for this tool. The analyzer intentionally does not read PST files because a PST export can
-include mail, contacts, tasks, and other mailbox data, not just calendar information. Use an `.ics` calendar export
-instead.
-
-Run the analyzer with the exported file:
-
-```bash
-just run --calendar ~/Documents/your-calendar.ics
-```
-
-On Windows PowerShell:
-
-```powershell
-just run --calendar "$HOME\Documents\your-calendar.ics"
-```
-
-## Usage
-
-```bash
-# Basic usage (analyzes past year)
-just run
-
-# Analyze specific date range
-just run --start-date 2024-01-01 --end-date 2024-03-31
-
-# Analyze last 90 days
-just run --days 90
-
-# Specify custom calendar file
-just run --calendar /path/to/your/calendar.olm
-
-# Force re-importing the newest discovered calendar and refreshing the default cache
-just run --import
-
-# Force re-importing a specific calendar and refreshing its default cache
-just run --calendar /path/to/your/calendar.olm --import
-
-# Force re-importing a specific calendar into a specific saved cache
-just run \
-  --calendar "/path/to/your/calendar.ics" \
-  --dataframe ~/.cache/calendar-analyzer/meetings.parquet \
-  --import
-
-# Use a specific saved Polars/Parquet data file
-just run --dataframe /path/to/meetings.parquet
-
-# Show top 10 meeting titles
-just run --titles 10
-
-# Show top 8 common meeting times
-just run --times 8
-
-# Exclude meeting titles by case-insensitive regex
-just run --exclude-title 'SVM|VMTH'
-
-# Repeat exclusions for separate title patterns
-just run --exclude-title 'SVM' --exclude-title 'VMTH|State of the Hospital'
-
-# Save results to file
-just run --output analysis.txt
-```
-
-The script looks for saved Polars/Parquet meeting data first, analyzes the requested date range from that data when
-available, and imports a calendar export when the saved data is missing or stale. With `--calendar`, the default cache is
-created next to the calendar export, such as `calendar.olm.parquet`. Without `--calendar`, the default cache is
-`~/.cache/calendar-analyzer/meetings.parquet`.
-
-Use `--import` when you want to ignore the existing saved Polars/Parquet file and rebuild it from the calendar export.
-Without `--calendar`, `--import` discovers the newest supported calendar export and refreshes the default cache. With
-`--calendar`, it imports that specific file. Add `--dataframe` when you want the refreshed cache written to a specific
-Parquet path, such as the default `~/.cache/calendar-analyzer/meetings.parquet`.
-
-On Windows, `scripts/setup-windows.ps1` installs Git for Windows so the Bash-backed `just` recipes work from PowerShell
-too. The default cache without `--calendar` is stored under `%LOCALAPPDATA%\calendar-analyzer\meetings.parquet`. Reports
-show both the imported data coverage and the requested query date range so you can tell whether an empty or small result
-came from the query window or from the calendar export itself.
+Both scripts run `just ci` by default. Use `--no-check` on macOS or `-NoCheck` on Windows to only install and sync
+dependencies. See [scripts/README.md](scripts/README.md) for script linting and formatting details.
 
 ## Development
 
@@ -215,7 +295,3 @@ just spell-check
 ```
 
 Configured in `typos.toml`.
-
-## Note
-
-This script reads your local calendar data and does not send any information to external servers. All processing is done locally on your machine.

--- a/calendar_analyzer.py
+++ b/calendar_analyzer.py
@@ -72,6 +72,7 @@ class SummaryOptions:
     period_end: datetime | None = None
     data_start: date | None = None
     data_end: date | None = None
+    include_data_coverage: bool = True
 
 
 SqliteCalendarRow = tuple[str | None, int, int, Any]
@@ -92,12 +93,12 @@ def print_calendar_export_instructions() -> None:
     """Print instructions for exporting a calendar file."""
     print("\nPlease export your calendar from Calendar or Outlook:")
     print("1. Apple Calendar: select the calendar, then use File > Export")
-    print("2. Outlook for Mac: export an Outlook archive (.olm), or export an ICS calendar when available")
-    print("3. Outlook for Windows: export a calendar-only ICS file with File > Save Calendar")
+    print("2. Microsoft Outlook for Mac: export an Outlook archive (.olm)")
+    print("3. Microsoft Outlook for Windows: export a calendar-only ICS file with File > Save Calendar")
     print("4. Do not export a PST file; PST can include mail, contacts, tasks, and other mailbox data")
     print("5. Save the calendar file")
     print("\nThen run this script with the path to your exported file:")
-    print("just run --calendar /path/to/your/calendar.ics")
+    print("calendar-analyzer --calendar /path/to/your/calendar.ics")
 
 
 def get_calendar_path(calendar_file: str | Path | None = None) -> Path:
@@ -223,14 +224,13 @@ def _import_outlook_csv_calendar_meetings(calendar_path: Path) -> list[Meeting]:
 
     try:
         rows = _read_outlook_csv_rows(calendar_path)
+        return _meetings_from_outlook_csv_rows(rows)
     except OSError as error:
         print(f"Error reading Outlook CSV calendar: {error}")
         raise_system_exit()
     except ValueError as error:
         print(f"Error parsing Outlook CSV calendar: {error}")
         raise_system_exit()
-
-    return _meetings_from_outlook_csv_rows(rows)
 
 
 def _import_olm_calendar_meetings(calendar_path: Path) -> list[Meeting]:
@@ -256,7 +256,7 @@ def generate_summary(
     options = options or SummaryOptions()
     if frame.is_empty():
         summary = ["No meetings found in the specified time period."]
-        if options.data_start is not None or options.data_end is not None:
+        if options.include_data_coverage and (options.data_start is not None or options.data_end is not None):
             summary.extend(
                 [
                     "\nImported Data Coverage:",
@@ -298,9 +298,6 @@ def generate_summary(
     summary = [
         f"📅 Calendar Analysis Summary (All times in Pacific Time - Currently {timezone_name})",
         "=" * 70,
-        "\nImported Data Coverage:",
-        f"- From: {_format_summary_date(imported_start_date)}",
-        f"- To:   {_format_summary_date(imported_end_date)}",
         "\nQuery Date Range:",
         f"- From: {query_start_date.strftime('%B %d, %Y')}",
         f"- To:   {query_end_date.strftime('%B %d, %Y')}",
@@ -317,6 +314,12 @@ def generate_summary(
         f"- Average Meeting Duration: {avg_meeting_duration:.1f} hours",
         f"\nTop {options.num_times} Most Common Meeting Times ({timezone_name}):",
     ]
+    if options.include_data_coverage:
+        summary[2:2] = [
+            "\nImported Data Coverage:",
+            f"- From: {_format_summary_date(imported_start_date)}",
+            f"- To:   {_format_summary_date(imported_end_date)}",
+        ]
 
     time_counts = (
         frame.group_by("time")
@@ -344,6 +347,25 @@ def generate_summary(
     return "\n".join(summary)
 
 
+def generate_ai_analysis_prompt(summary: str) -> str:
+    """Wrap a calendar summary in a prompt suitable for AI analysis."""
+    return (
+        "Please analyze this calendar summary so I can understand how my meeting time was spent.\n\n"
+        "Use the data below to:\n"
+        "- summarize the week or selected date range in plain language,\n"
+        "- describe how my time was spent across recurring meeting themes,\n"
+        "- identify likely accomplishments, decisions, or workstreams represented by the meetings,\n"
+        "- draft concise bullets I could adapt for weekly updates or year-end accomplishment summaries,\n"
+        "- point out schedule patterns, meeting load, and follow-up questions that would improve the analysis.\n\n"
+        "Privacy note: this summary was generated locally. It may include private meeting titles "
+        "because I chose to paste it here.\n\n"
+        "Calendar summary:\n"
+        "```text\n"
+        f"{summary.strip()}\n"
+        "```"
+    )
+
+
 def main() -> None:
     """Run the calendar analyzer command-line interface."""
     args = _parse_args()
@@ -353,6 +375,7 @@ def main() -> None:
     excluded_title_patterns = _compile_title_exclusion_patterns(args.exclude_titles)
     start_date, end_date = _resolve_date_range(requested_start_date, requested_end_date, args.days)
     dataframe_path = _resolve_dataframe_path(args.dataframe, args.calendar)
+    output_path = _resolve_output_path(args.output, generate_prompt=args.generate_prompt)
 
     print("📊 Analyzing your calendar...")
     meetings_frame = load_calendar_dataframe(
@@ -363,6 +386,13 @@ def main() -> None:
     data_start, data_end = _frame_date_bounds(meetings_frame)
     meetings_frame = _filter_meetings_frame(meetings_frame, start_date, end_date)
     meetings_frame = _exclude_title_matches_frame(meetings_frame, excluded_title_patterns)
+    if (
+        args.generate_prompt
+        and meetings_frame.is_empty()
+        and not _date_range_overlaps_data(start_date, end_date, data_start, data_end)
+    ):
+        _print_prompt_range_error(start_date, end_date, data_start, data_end)
+        raise_system_exit()
     summary = generate_summary(
         meetings_frame,
         options=SummaryOptions(
@@ -372,9 +402,12 @@ def main() -> None:
             period_end=end_date,
             data_start=data_start,
             data_end=data_end,
+            include_data_coverage=not args.generate_prompt,
         ),
     )
-    _write_or_print_summary(summary, args.output)
+    formatted_output = _format_output(summary, generate_prompt=args.generate_prompt)
+    output_label = "Prompt" if args.generate_prompt else "Analysis"
+    _write_or_print_summary(formatted_output, output_path, output_label=output_label)
 
 
 def raise_system_exit() -> NoReturn:
@@ -402,16 +435,10 @@ def _resolve_requested_calendar_path(calendar_file: str | Path) -> Path:
     return calendar_path
 
 
-def _resolve_dataframe_path(dataframe_file: str | Path | None, calendar_file: str | Path | None) -> Path:
+def _resolve_dataframe_path(dataframe_file: str | Path | None, _calendar_file: str | Path | None) -> Path:
     """Return the saved Polars DataFrame path for this run."""
     if dataframe_file is not None:
         return Path(dataframe_file).expanduser().resolve()
-
-    if calendar_file is not None:
-        calendar_path = Path(calendar_file).expanduser()
-        if calendar_path.suffix:
-            return calendar_path.with_suffix(f"{calendar_path.suffix}.parquet").resolve()
-        return calendar_path.with_suffix(".parquet").resolve()
 
     return (_user_cache_directory() / "meetings.parquet").resolve()
 
@@ -498,6 +525,34 @@ def _frame_date_bounds(frame: pl.DataFrame) -> tuple[date | None, date | None]:
         return None, None
     bounds = frame.select(pl.col("date").min().alias("start"), pl.col("date").max().alias("end")).row(0, named=True)
     return bounds["start"], bounds["end"]
+
+
+def _date_range_overlaps_data(
+    period_start: datetime,
+    period_end: datetime,
+    data_start: date | None,
+    data_end: date | None,
+) -> bool:
+    """Return whether a requested period overlaps saved meeting data coverage."""
+    if data_start is None or data_end is None:
+        return True
+    return period_start.date() <= data_end and period_end.date() >= data_start
+
+
+def _print_prompt_range_error(
+    period_start: datetime,
+    period_end: datetime,
+    data_start: date | None,
+    data_end: date | None,
+) -> None:
+    """Print a clear error when prompt dates are outside cached data coverage."""
+    print("Error: no cached meeting data overlaps the requested prompt date range.")
+    print(f"Cached meeting data covers: {_format_summary_date(data_start)} to {_format_summary_date(data_end)}")
+    print(
+        "Requested prompt range: "
+        f"{_format_summary_date(period_start.date())} to {_format_summary_date(period_end.date())}"
+    )
+    print("Refresh the cache with: calendar-analyzer --import")
 
 
 def _format_summary_date(value: date | None) -> str:
@@ -1068,10 +1123,17 @@ def _validate_outlook_csv_headers(fieldnames: Iterable[str]) -> None:
 def _meetings_from_outlook_csv_rows(rows: Iterable[dict[str, str]]) -> list[Meeting]:
     """Normalize Outlook CSV rows."""
     meetings: list[Meeting] = []
+    unparsable_start_values: list[str] = []
 
     for row in rows:
+        if _outlook_csv_row_is_non_meeting(row):
+            continue
+
+        start_value = _outlook_csv_start_value_for_diagnostics(row)
         start = _outlook_csv_start_datetime(row)
         if start is None:
+            if start_value is not None:
+                unparsable_start_values.append(start_value)
             continue
 
         start = convert_to_pacific(start)
@@ -1090,20 +1152,45 @@ def _meetings_from_outlook_csv_rows(rows: Iterable[dict[str, str]]) -> list[Meet
             }
         )
 
+    if not meetings and unparsable_start_values:
+        examples = ", ".join(unparsable_start_values[:3])
+        msg = f"Could not parse any Outlook CSV start dates. Example value(s): {examples}"
+        raise ValueError(msg)
+
     return meetings
 
 
 def _outlook_csv_start_datetime(row: dict[str, str]) -> datetime | None:
     """Return the row start datetime, skipping all-day rows."""
-    if _csv_truthy(_csv_value(row, ("All day event", "All Day Event", "All Day", "AllDayEvent"))):
-        return None
-    if _is_non_meeting_free_busy(_csv_value(row, ("Show Time As", "Show As", "Busy Status", "FreeBusyStatus"))):
+    if _outlook_csv_row_is_non_meeting(row):
         return None
 
     return _outlook_split_datetime(row, ("Start Date", "StartDate"), ("Start Time", "StartTime")) or _outlook_datetime(
         _csv_value(row, ("Start", "Starts", "Start Date Time", "StartDateTime")),
         require_time=True,
     )
+
+
+def _outlook_csv_row_is_non_meeting(row: dict[str, str]) -> bool:
+    """Return whether an Outlook CSV row should be skipped as non-meeting time."""
+    return _csv_truthy(
+        _csv_value(row, ("All day event", "All Day Event", "All Day", "AllDayEvent"))
+    ) or _is_non_meeting_free_busy(_csv_value(row, ("Show Time As", "Show As", "Busy Status", "FreeBusyStatus")))
+
+
+def _outlook_csv_start_value_for_diagnostics(row: dict[str, str]) -> str | None:
+    """Return a timed-looking CSV start value that failed parsing, or None for date-only rows."""
+    combined_start = _csv_value(row, ("Start", "Starts", "Start Date Time", "StartDateTime"))
+    if combined_start is not None and _outlook_text_has_time(combined_start):
+        return combined_start
+
+    start_date = _csv_value(row, ("Start Date", "StartDate"))
+    start_time = _csv_value(row, ("Start Time", "StartTime"))
+    if start_date is not None and start_time is not None:
+        return f"{start_date} {start_time}"
+    if start_date is None and start_time is not None:
+        return start_time
+    return None
 
 
 def _outlook_csv_end_datetime(row: dict[str, str], start: datetime) -> datetime:
@@ -1433,10 +1520,7 @@ def _parse_args() -> argparse.Namespace:
     """Parse command-line arguments for the calendar analyzer CLI."""
     parser = argparse.ArgumentParser(description="Analyze calendar events from a specified date range.")
     parser.add_argument("--calendar", help="Path to the exported calendar file (.ics, .olm, .csv, .icbu, .sqlitedb)")
-    parser.add_argument(
-        "--dataframe",
-        help="Path to the saved Polars/Parquet meeting data (default: derived from --calendar or user cache)",
-    )
+    parser.add_argument("--dataframe", help="Path to the saved Polars/Parquet meeting data (default: user cache)")
     parser.add_argument(
         "--import",
         action="store_true",
@@ -1469,7 +1553,12 @@ def _parse_args() -> argparse.Namespace:
         dest="exclude_titles",
         help="Case-insensitive regex for meeting titles to exclude from statistics; may be repeated",
     )
-    parser.add_argument("--output", help="Path to save the analysis summary (default: print to console)")
+    parser.add_argument(
+        "--generate-prompt",
+        action="store_true",
+        help="Wrap the summary in a paste-ready AI analysis prompt",
+    )
+    parser.add_argument("--output", help="Path to save the analysis summary or prompt")
     return parser.parse_args()
 
 
@@ -1515,7 +1604,14 @@ def _validate_date_range(start_date: datetime | None, end_date: datetime | None)
     raise_system_exit()
 
 
-def _write_or_print_summary(summary: str, output: str | None) -> None:
+def _resolve_output_path(output: str | None, *, generate_prompt: bool) -> str | None:
+    """Return the output path for this run."""
+    if output is not None or not generate_prompt:
+        return output
+    return "calendar-prompt.txt"
+
+
+def _write_or_print_summary(summary: str, output: str | None, *, output_label: str = "Analysis") -> None:
     """Write the summary to a file or print it when no output path is supplied."""
     if output is None:
         _write_summary_to_stdout(summary)
@@ -1527,7 +1623,14 @@ def _write_or_print_summary(summary: str, output: str | None) -> None:
         print(f"Error saving to file: {error}")
         raise_system_exit()
 
-    print(f"\nAnalysis saved to: {output}")
+    print(f"\n{output_label} saved to: {output}")
+
+
+def _format_output(summary: str, *, generate_prompt: bool) -> str:
+    """Return the requested user-facing output format."""
+    if generate_prompt:
+        return generate_ai_analysis_prompt(summary)
+    return summary
 
 
 def _write_summary_to_stdout(summary: str) -> None:

--- a/tests/test_calendar_analyzer.py
+++ b/tests/test_calendar_analyzer.py
@@ -465,10 +465,10 @@ def test_print_calendar_export_instructions(capsys) -> None:
     out = capsys.readouterr().out
     assert "Please export your calendar from Calendar or Outlook:" in out
     assert "Apple Calendar: select the calendar, then use File > Export" in out
-    assert "Outlook for Mac: export an Outlook archive (.olm), or export an ICS calendar when available" in out
-    assert "Outlook for Windows: export a calendar-only ICS file" in out
+    assert "Microsoft Outlook for Mac: export an Outlook archive (.olm)" in out
+    assert "Microsoft Outlook for Windows: export a calendar-only ICS file" in out
     assert "Do not export a PST file" in out
-    assert "just run --calendar" in out
+    assert "calendar-analyzer --calendar" in out
 
 
 def test_generate_summary_no_meetings() -> None:
@@ -543,6 +543,131 @@ def test_file_output_functionality(monkeypatch, capsys) -> None:
     # Clean up
     Path(tmp_ics_path).unlink()
     Path(output_path).unlink()
+
+
+def test_generate_prompt_uses_saved_dataframe_without_calendar(monkeypatch, capsys, tmp_path: Path) -> None:
+    """Test generating a paste-ready AI prompt from cached meeting data."""
+    calendar_path = tmp_path / "calendar.ics"
+    cache_dir = tmp_path / "cache"
+    output_path = tmp_path / "calendar-prompt.txt"
+    calendar_path.write_text(
+        textwrap.dedent("""
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        BEGIN:VEVENT
+        DTSTART:20230701T170000Z
+        DURATION:PT1H
+        SUMMARY:Prompt Format Meeting
+        END:VEVENT
+        END:VCALENDAR
+        """),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(calendar_analyzer, "_user_cache_directory", lambda: cache_dir)
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "calendar-analyzer",
+            "--calendar",
+            str(calendar_path),
+            "--start-date",
+            "2023-06-30",
+            "--end-date",
+            "2023-07-03",
+        ],
+    )
+    calendar_analyzer.main()
+    capsys.readouterr()
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "calendar-analyzer",
+            "--start-date",
+            "2023-06-30",
+            "--end-date",
+            "2023-07-03",
+            "--generate-prompt",
+        ],
+    )
+    calendar_analyzer.main()
+
+    captured = capsys.readouterr()
+    content = output_path.read_text(encoding="utf-8")
+    assert content.startswith("Please analyze this calendar summary so I can understand how my meeting time was spent.")
+    assert "draft concise bullets I could adapt for weekly updates or year-end accomplishment summaries" in content
+    assert "Privacy note: this summary was generated locally." in content
+    assert "Calendar summary:\n```text" in content
+    assert "Calendar Analysis Summary" in content
+    assert "Query Date Range:" in content
+    assert "Imported Data Coverage:" not in content
+    assert "Prompt Format Meeting" in content
+    assert content.endswith("```")
+    assert f"Found saved Polars DataFrame at: {cache_dir / 'meetings.parquet'}" in captured.out
+    assert f"Prompt saved to: {output_path.name}" in captured.out
+    assert "No calendar files found" not in captured.out
+
+
+def test_generate_prompt_errors_when_requested_range_is_outside_cache(monkeypatch, capsys, tmp_path: Path) -> None:
+    """Test prompt generation explains when cached data does not cover the requested range."""
+    calendar_path = tmp_path / "calendar.ics"
+    cache_dir = tmp_path / "cache"
+    output_path = tmp_path / "calendar-prompt.txt"
+    calendar_path.write_text(
+        textwrap.dedent("""
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        BEGIN:VEVENT
+        DTSTART:20230701T170000Z
+        DURATION:PT1H
+        SUMMARY:Cached Meeting
+        END:VEVENT
+        END:VCALENDAR
+        """),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(calendar_analyzer, "_user_cache_directory", lambda: cache_dir)
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "calendar-analyzer",
+            "--calendar",
+            str(calendar_path),
+            "--start-date",
+            "2023-06-30",
+            "--end-date",
+            "2023-07-03",
+        ],
+    )
+    calendar_analyzer.main()
+    capsys.readouterr()
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "calendar-analyzer",
+            "--start-date",
+            "2025-05-01",
+            "--end-date",
+            "2026-04-30",
+            "--generate-prompt",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.main()
+
+    assert exc_info.value.code == 1
+    assert not output_path.exists()
+    out = capsys.readouterr().out
+    assert "Error: no cached meeting data overlaps the requested prompt date range." in out
+    assert "Cached meeting data covers: July 01, 2023 to July 01, 2023" in out
+    assert "Requested prompt range: May 01, 2025 to April 30, 2026" in out
+    assert "Refresh the cache with: calendar-analyzer --import" in out
 
 
 def test_file_output_error(monkeypatch, capsys) -> None:
@@ -2190,6 +2315,51 @@ def test_analyze_calendar_outlook_csv_requires_start_columns(capsys, tmp_path: P
     out = capsys.readouterr().out
     assert "Error parsing Outlook CSV calendar:" in out
     assert "CSV must include Outlook start columns" in out
+
+
+def test_analyze_calendar_outlook_csv_errors_when_timed_starts_do_not_parse(capsys, tmp_path: Path) -> None:
+    """Test Outlook CSV analysis reports timed-looking rows with unsupported start dates."""
+    csv_path = tmp_path / "calendar.csv"
+    csv_path.write_text(
+        textwrap.dedent("""\
+        Subject,Start Date,Start Time,End Date,End Time
+        Broken Start,not-a-date,10:00 AM,07/01/2023,11:00 AM
+        Another Broken Start,07/02/2023,not-a-time,07/02/2023,11:00 AM
+        """),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.analyze_calendar(csv_path)
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error parsing Outlook CSV calendar: Could not parse any Outlook CSV start dates." in out
+    assert "not-a-date 10:00 AM" in out
+    assert "07/02/2023 not-a-time" in out
+
+
+def test_analyze_calendar_outlook_csv_errors_when_combined_start_does_not_parse(
+    capsys,
+    tmp_path: Path,
+) -> None:
+    """Test Outlook CSV analysis reports unsupported combined start values."""
+    csv_path = tmp_path / "calendar.csv"
+    csv_path.write_text(
+        textwrap.dedent("""\
+        Subject,Start,End
+        Broken Combined Start,not-a-date 10:00 AM,2023-07-01 11:00:00
+        """),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.analyze_calendar(csv_path)
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error parsing Outlook CSV calendar: Could not parse any Outlook CSV start dates." in out
+    assert "not-a-date 10:00 AM" in out
 
 
 def test_analyze_calendar_filters_requested_outlook_csv_range(tmp_path: Path) -> None:


### PR DESCRIPTION
Add a --generate-prompt mode that writes a ChatGPT/Claude-ready prompt file from cached calendar data.

- Use the default user cache for calendar imports so later reports and prompts can reuse the first imported calendar data.
- Omit imported-data coverage from prompt files while preserving the requested query range and meeting summary details.
- Refuse to write a prompt when the requested date range is outside cached data coverage, with a clear --import refresh hint.
- Improve Outlook CSV diagnostics for timed rows with unparseable start values.
- Refresh README guidance for uv-based usage, development setup, Outlook export paths, local privacy, and AI analysis.