### PR TITLE
fix(cli): reject invalid meeting and cache state

### DIFF
--- a/calendar_analyzer.py
+++ b/calendar_analyzer.py
@@ -151,6 +151,111 @@ class SummaryOptions:
             raise ValueError(msg)
 
 
+@dataclass(frozen=True, slots=True)
+class CacheMetadata:
+    """Validated sidecar metadata for a saved meeting DataFrame."""
+
+    schema_version: int
+    source_path: str
+    source_mtime_ns: int | None
+    source_size: int | None
+    data_start: calendar_date | None = None
+    data_end: calendar_date | None = None
+
+    def __post_init__(self) -> None:
+        """Validate cache metadata fields parsed from JSON."""
+        if isinstance(self.schema_version, bool) or not isinstance(self.schema_version, int):
+            msg = f"cache metadata schema_version must be an integer, got {self.schema_version!r}"
+            raise TypeError(msg)
+        if not isinstance(self.source_path, str) or not self.source_path:
+            msg = f"cache metadata source_path must be a non-empty string, got {self.source_path!r}"
+            raise ValueError(msg)
+        if self.source_mtime_ns is not None and (
+            isinstance(self.source_mtime_ns, bool) or not isinstance(self.source_mtime_ns, int)
+        ):
+            msg = f"cache metadata source_mtime_ns must be an integer or null, got {self.source_mtime_ns!r}"
+            raise TypeError(msg)
+        if self.source_size is not None and (
+            isinstance(self.source_size, bool) or not isinstance(self.source_size, int)
+        ):
+            msg = f"cache metadata source_size must be an integer or null, got {self.source_size!r}"
+            raise TypeError(msg)
+        if self.data_start is not None and not isinstance(self.data_start, calendar_date):
+            msg = f"cache metadata data_start must be a date or null, got {self.data_start!r}"
+            raise TypeError(msg)
+        if self.data_end is not None and not isinstance(self.data_end, calendar_date):
+            msg = f"cache metadata data_end must be a date or null, got {self.data_end!r}"
+            raise TypeError(msg)
+        if self.data_start is not None and self.data_end is not None and self.data_end < self.data_start:
+            msg = "cache metadata data_end cannot be before data_start"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_raw(cls, raw_metadata: object) -> CacheMetadata:
+        """Parse raw JSON metadata into validated cache metadata."""
+        if not isinstance(raw_metadata, dict):
+            msg = f"cache metadata must be a JSON object, got {raw_metadata!r}"
+            raise TypeError(msg)
+        metadata_values: dict[str, object] = {key: value for key, value in raw_metadata.items() if isinstance(key, str)}
+        return cls(
+            schema_version=_parse_metadata_int(metadata_values.get("schema_version"), "schema_version"),
+            source_path=_parse_metadata_source_path(metadata_values.get("source_path")),
+            source_mtime_ns=_parse_optional_metadata_int(metadata_values.get("source_mtime_ns"), "source_mtime_ns"),
+            source_size=_parse_optional_metadata_int(metadata_values.get("source_size"), "source_size"),
+            data_start=_parse_optional_metadata_date(metadata_values.get("data_start"), "data_start"),
+            data_end=_parse_optional_metadata_date(metadata_values.get("data_end"), "data_end"),
+        )
+
+    def to_json(self) -> str:
+        """Return cache metadata as deterministic JSON sidecar text."""
+        metadata = {
+            "schema_version": self.schema_version,
+            "source_path": self.source_path,
+            "source_mtime_ns": self.source_mtime_ns,
+            "source_size": self.source_size,
+            "data_start": self.data_start.isoformat() if self.data_start is not None else None,
+            "data_end": self.data_end.isoformat() if self.data_end is not None else None,
+        }
+        return json.dumps(metadata, indent=2, sort_keys=True)
+
+
+def _parse_metadata_int(value: object, field_name: str) -> int:
+    """Parse an integer field from cache metadata."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f"cache metadata {field_name} must be an integer, got {value!r}"
+        raise TypeError(msg)
+    return value
+
+
+def _parse_optional_metadata_int(value: object, field_name: str) -> int | None:
+    """Parse an optional integer field from cache metadata."""
+    if value is None:
+        return None
+    return _parse_metadata_int(value, field_name)
+
+
+def _parse_metadata_source_path(value: object) -> str:
+    """Parse the source path field from cache metadata."""
+    if not isinstance(value, str) or not value:
+        msg = f"cache metadata source_path must be a non-empty string, got {value!r}"
+        raise ValueError(msg)
+    return value
+
+
+def _parse_optional_metadata_date(value: object, field_name: str) -> calendar_date | None:
+    """Parse an optional ISO date from cache metadata."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        msg = f"cache metadata {field_name} must be an ISO date string or null, got {value!r}"
+        raise TypeError(msg)
+    try:
+        return calendar_date.fromisoformat(value)
+    except ValueError as error:
+        msg = f"cache metadata {field_name} must be an ISO date string, got {value!r}"
+        raise ValueError(msg) from error
+
+
 SqliteCalendarRow = tuple[str | None, Any, Any, Any]
 
 
@@ -640,7 +745,7 @@ def main() -> None:
 
 def raise_system_exit() -> NoReturn:
     """Exit with the conventional CLI failure status."""
-    sys.exit(1)
+    argparse.ArgumentParser(prog="calendar-analyzer").exit(1)
 
 
 def _resolve_requested_calendar_path(calendar_file: str | Path) -> Path:
@@ -688,7 +793,7 @@ def _cached_dataframe_is_usable(dataframe_path: Path, calendar_file: str | Path 
         return False
 
     metadata = _read_cache_metadata(dataframe_path)
-    if metadata.get("schema_version") != CACHE_SCHEMA_VERSION:
+    if metadata is None or metadata.schema_version != CACHE_SCHEMA_VERSION:
         return False
 
     if calendar_file is None:
@@ -702,14 +807,14 @@ def _cached_dataframe_is_usable(dataframe_path: Path, calendar_file: str | Path 
     return _metadata_matches_calendar(metadata, calendar_path)
 
 
-def _metadata_matches_calendar(metadata: dict[str, object], calendar_path: Path) -> bool:
+def _metadata_matches_calendar(metadata: CacheMetadata, calendar_path: Path) -> bool:
     """Return whether saved DataFrame metadata matches a requested calendar source."""
     try:
         source_path = _resolve_calendar_source_path(calendar_path)
     except OSError:
         return False
 
-    if metadata.get("source_path") != str(source_path):
+    if metadata.source_path != str(source_path):
         return False
 
     try:
@@ -717,19 +822,17 @@ def _metadata_matches_calendar(metadata: dict[str, object], calendar_path: Path)
     except OSError:
         return False
 
-    return (
-        metadata.get("source_mtime_ns") == source_stat.st_mtime_ns
-        and metadata.get("source_size") == source_stat.st_size
-    )
+    return metadata.source_mtime_ns == source_stat.st_mtime_ns and metadata.source_size == source_stat.st_size
 
 
-def _read_cache_metadata(dataframe_path: Path) -> dict[str, object]:
-    """Read saved DataFrame sidecar metadata, returning an empty mapping when absent."""
+def _read_cache_metadata(dataframe_path: Path) -> CacheMetadata | None:
+    """Read and parse saved DataFrame sidecar metadata."""
     metadata_path = _cache_metadata_path(dataframe_path)
     try:
-        return json.loads(metadata_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
+        raw_metadata: object = json.loads(metadata_path.read_text(encoding="utf-8"))
+        return CacheMetadata.from_raw(raw_metadata)
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None
 
 
 def _cache_metadata_path(dataframe_path: Path) -> Path:
@@ -876,12 +979,8 @@ def _resolve_date_range(
     return resolved_start_date, resolved_end_date
 
 
-def _fetch_sqlite_calendar_rows(
-    calendar_path: Path,
-    start_seconds: int | None = None,
-    end_seconds: int | None = None,
-) -> list[SqliteCalendarRow]:
-    """Fetch SQLite calendar rows, optionally in an Apple-epoch date range."""
+def _fetch_sqlite_calendar_rows(calendar_path: Path) -> list[SqliteCalendarRow]:
+    """Fetch SQLite calendar rows."""
     with closing(sqlite3.connect(calendar_path)) as conn:
         cursor = conn.cursor()
         all_day_column = _sqlite_all_day_column(cursor)
@@ -895,12 +994,8 @@ def _fetch_sqlite_calendar_rows(
                 {all_day_expression}
             FROM CalendarItem
             """  # noqa: S608
-        parameters: tuple[int, int] | tuple[()] = ()
-        if start_seconds is not None and end_seconds is not None:
-            query += " WHERE start_date >= ? AND start_date <= ?"
-            parameters = (start_seconds, end_seconds)
         query += " ORDER BY start_date, summary"
-        cursor.execute(query, parameters)
+        cursor.execute(query)
         return cursor.fetchall()
 
 
@@ -1613,15 +1708,14 @@ def _cache_metadata(calendar_path: Path, frame: pl.DataFrame) -> str:
         source_size = source_stat.st_size
 
     data_start, data_end = _frame_date_bounds(frame)
-    metadata = {
-        "schema_version": CACHE_SCHEMA_VERSION,
-        "source_path": str(source_path),
-        "source_mtime_ns": source_mtime_ns,
-        "source_size": source_size,
-        "data_start": data_start.isoformat() if data_start is not None else None,
-        "data_end": data_end.isoformat() if data_end is not None else None,
-    }
-    return json.dumps(metadata, indent=2, sort_keys=True)
+    return CacheMetadata(
+        schema_version=CACHE_SCHEMA_VERSION,
+        source_path=str(source_path),
+        source_mtime_ns=source_mtime_ns,
+        source_size=source_size,
+        data_start=data_start,
+        data_end=data_end,
+    ).to_json()
 
 
 def _compile_title_exclusion_patterns(patterns: list[str] | None) -> list[re.Pattern[str]]:

--- a/calendar_analyzer.py
+++ b/calendar_analyzer.py
@@ -6,6 +6,7 @@ import argparse
 import csv
 import importlib
 import json
+import math
 import os
 import re
 import sqlite3
@@ -14,9 +15,9 @@ import tempfile
 import zipfile
 from contextlib import closing, suppress
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, time, timedelta
+from datetime import UTC, date as calendar_date, datetime, time as clock_time, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NoReturn, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, overload
 from zoneinfo import ZoneInfo
 
 import polars as pl
@@ -54,14 +55,72 @@ OUTLOOK_DATETIME_FORMATS = (
 )
 
 
-class Meeting(TypedDict):
-    """Normalized calendar meeting data used for reporting."""
+@dataclass(frozen=True, slots=True)
+class Meeting:
+    """Validated calendar meeting data used for reporting."""
 
     start: datetime
-    date: date
-    time: time
     summary: str
     duration_hours: float
+
+    def __post_init__(self) -> None:
+        """Validate invariant-bearing meeting fields."""
+        if not isinstance(self.start, datetime):
+            msg = f"Meeting start must be a datetime, got {self.start!r}"
+            raise TypeError(msg)
+        if not isinstance(self.summary, str) or not self.summary:
+            msg = f"Meeting summary must be a non-empty string, got {self.summary!r}"
+            raise ValueError(msg)
+        if (
+            isinstance(self.duration_hours, bool)
+            or not isinstance(self.duration_hours, int | float)
+            or not math.isfinite(self.duration_hours)
+            or self.duration_hours <= 0
+        ):
+            msg = f"Meeting duration_hours must be positive and finite, got {self.duration_hours!r}"
+            raise ValueError(msg)
+
+    @property
+    def date(self) -> calendar_date:
+        """Return the Pacific calendar date derived from the validated start."""
+        return convert_to_pacific(self.start).date()
+
+    @property
+    def time(self) -> clock_time:
+        """Return the Pacific local time derived from the validated start."""
+        return convert_to_pacific(self.start).time()
+
+    @overload
+    def __getitem__(self, key: Literal["start"]) -> datetime: ...
+
+    @overload
+    def __getitem__(self, key: Literal["date"]) -> calendar_date: ...
+
+    @overload
+    def __getitem__(self, key: Literal["time"]) -> clock_time: ...
+
+    @overload
+    def __getitem__(self, key: Literal["summary"]) -> str: ...
+
+    @overload
+    def __getitem__(self, key: Literal["duration_hours"]) -> float: ...
+
+    def __getitem__(
+        self,
+        key: Literal["start", "date", "time", "summary", "duration_hours"],
+    ) -> datetime | calendar_date | clock_time | str | float:
+        """Return fields by legacy mapping-style keys."""
+        if key == "start":
+            return self.start
+        if key == "date":
+            return self.date
+        if key == "time":
+            return self.time
+        if key == "summary":
+            return self.summary
+        if key == "duration_hours":
+            return self.duration_hours
+        raise KeyError(key)
 
 
 @dataclass(frozen=True)
@@ -72,12 +131,27 @@ class SummaryOptions:
     num_times: int = 5
     period_start: datetime | None = None
     period_end: datetime | None = None
-    data_start: date | None = None
-    data_end: date | None = None
+    data_start: calendar_date | None = None
+    data_end: calendar_date | None = None
     include_data_coverage: bool = True
 
+    def __post_init__(self) -> None:
+        """Validate display option invariants."""
+        if self.num_titles <= 0:
+            msg = f"num_titles must be positive, got {self.num_titles!r}"
+            raise ValueError(msg)
+        if self.num_times <= 0:
+            msg = f"num_times must be positive, got {self.num_times!r}"
+            raise ValueError(msg)
+        if self.period_start is not None and self.period_end is not None and self.period_end < self.period_start:
+            msg = "period_end cannot be before period_start"
+            raise ValueError(msg)
+        if self.data_start is not None and self.data_end is not None and self.data_end < self.data_start:
+            msg = "data_end cannot be before data_start"
+            raise ValueError(msg)
 
-SqliteCalendarRow = tuple[str | None, int, int, Any]
+
+SqliteCalendarRow = tuple[str | None, Any, Any, Any]
 
 
 class SavedDataFrameReadError(RuntimeError):
@@ -197,7 +271,7 @@ def import_calendar_meetings(calendar_path: Path) -> list[Meeting]:
 
     print(f"Error: Unsupported calendar file type: {calendar_path.suffix or '<none>'}")
     print("Supported calendar exports are .icbu, .sqlitedb, .olm, .pst, and explicit Outlook .csv files.")
-    raise SystemExit(1)
+    return raise_system_exit()
 
 
 def _import_sqlite_calendar_meetings(calendar_path: Path) -> list[Meeting]:
@@ -205,11 +279,13 @@ def _import_sqlite_calendar_meetings(calendar_path: Path) -> list[Meeting]:
 
     try:
         rows = _fetch_sqlite_calendar_rows(calendar_path)
+        return _meetings_from_sqlite_rows(rows)
     except sqlite3.Error as error:
         print(f"Error reading SQLite calendar: {error}")
         raise_system_exit()
-
-    return _meetings_from_sqlite_rows(rows)
+    except (TypeError, ValueError) as error:
+        print(f"Error parsing SQLite calendar: {error}")
+        raise_system_exit()
 
 
 def _import_outlook_csv_calendar_meetings(calendar_path: Path) -> list[Meeting]:
@@ -383,13 +459,11 @@ def _meeting_from_outlook_appointment(item: Any) -> Meeting | None:
     if _is_all_day_like_calendar_block(start, duration_hours):
         return None
 
-    return {
-        "start": start,
-        "date": start.date(),
-        "time": start.time(),
-        "summary": str(getattr(item, "Subject", "") or "No Title"),
-        "duration_hours": duration_hours,
-    }
+    return Meeting(
+        start=start,
+        summary=str(getattr(item, "Subject", "") or "No Title"),
+        duration_hours=duration_hours,
+    )
 
 
 def _outlook_com_datetime(value: object) -> datetime | None:
@@ -673,7 +747,7 @@ def _print_frame_coverage(label: str, frame: pl.DataFrame) -> None:
     print(f"{label}: {_format_summary_date(start_date)} to {_format_summary_date(end_date)}")
 
 
-def _frame_date_bounds(frame: pl.DataFrame) -> tuple[date | None, date | None]:
+def _frame_date_bounds(frame: pl.DataFrame) -> tuple[calendar_date | None, calendar_date | None]:
     """Return the min and max dates covered by a normalized meeting DataFrame."""
     if frame.is_empty():
         return None, None
@@ -684,8 +758,8 @@ def _frame_date_bounds(frame: pl.DataFrame) -> tuple[date | None, date | None]:
 def _date_range_overlaps_data(
     period_start: datetime,
     period_end: datetime,
-    data_start: date | None,
-    data_end: date | None,
+    data_start: calendar_date | None,
+    data_end: calendar_date | None,
 ) -> bool:
     """Return whether a requested period overlaps saved meeting data coverage."""
     if data_start is None or data_end is None:
@@ -696,8 +770,8 @@ def _date_range_overlaps_data(
 def _print_prompt_range_error(
     period_start: datetime,
     period_end: datetime,
-    data_start: date | None,
-    data_end: date | None,
+    data_start: calendar_date | None,
+    data_end: calendar_date | None,
 ) -> None:
     """Print a clear error when prompt dates are outside cached data coverage."""
     print("Error: no cached meeting data overlaps the requested prompt date range.")
@@ -709,7 +783,7 @@ def _print_prompt_range_error(
     print("Refresh the cache with: calendar-analyzer --import")
 
 
-def _format_summary_date(value: date | None) -> str:
+def _format_summary_date(value: calendar_date | None) -> str:
     """Format an optional date for user-facing coverage output."""
     if value is None:
         return "No timed meetings"
@@ -853,23 +927,28 @@ def _meetings_from_sqlite_rows(rows: Iterable[SqliteCalendarRow]) -> list[Meetin
         if _csv_truthy(str(is_all_day)):
             continue
 
-        start_dt = convert_to_pacific(APPLE_EPOCH + timedelta(seconds=start_seconds))
-        end_dt = convert_to_pacific(APPLE_EPOCH + timedelta(seconds=end_seconds))
+        title = summary or "No Title"
+        start_dt = convert_to_pacific(
+            APPLE_EPOCH + timedelta(seconds=_sqlite_calendar_seconds(start_seconds, "start_date", title))
+        )
+        end_dt = convert_to_pacific(
+            APPLE_EPOCH + timedelta(seconds=_sqlite_calendar_seconds(end_seconds, "end_date", title))
+        )
         duration_hours = _positive_duration_hours(start_dt, end_dt)
         if _is_all_day_like_calendar_block(start_dt, duration_hours):
             continue
 
-        meetings.append(
-            {
-                "start": start_dt,
-                "date": start_dt.date(),
-                "time": start_dt.time(),
-                "summary": summary or "No Title",
-                "duration_hours": duration_hours,
-            }
-        )
+        meetings.append(Meeting(start=start_dt, summary=title, duration_hours=duration_hours))
 
     return meetings
+
+
+def _sqlite_calendar_seconds(value: object, field_name: str, title: str) -> int | float:
+    """Return Apple-epoch seconds from a SQLite row or raise a parse error."""
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        msg = f"CalendarItem row {title!r} has invalid {field_name}: {value!r}"
+        raise TypeError(msg)
+    return value
 
 
 def _read_olm_appointments(calendar_path: Path) -> list[Element]:
@@ -927,13 +1006,11 @@ def _meetings_from_olm_appointments(appointments: Iterable[Element]) -> list[Mee
             continue
 
         meetings.append(
-            {
-                "start": start,
-                "date": start.date(),
-                "time": start.time(),
-                "summary": _xml_text(appointment, ("OPFCalendarEventCopySummary", "Subject", "Summary")) or "No Title",
-                "duration_hours": duration_hours,
-            }
+            Meeting(
+                start=start,
+                summary=_xml_text(appointment, ("OPFCalendarEventCopySummary", "Subject", "Summary")) or "No Title",
+                duration_hours=duration_hours,
+            )
         )
 
     if dated_appointments and dated_appointments == len(unparsable_start_values):
@@ -1131,13 +1208,11 @@ def _meetings_from_outlook_csv_rows(rows: Iterable[dict[str, str]]) -> list[Meet
             continue
 
         meetings.append(
-            {
-                "start": start,
-                "date": start.date(),
-                "time": start.time(),
-                "summary": _csv_value(row, ("Subject", "Title", "Summary")) or "No Title",
-                "duration_hours": duration_hours,
-            }
+            Meeting(
+                start=start,
+                summary=_csv_value(row, ("Subject", "Title", "Summary")) or "No Title",
+                duration_hours=duration_hours,
+            )
         )
 
     if not meetings and unparsable_start_values:
@@ -1311,7 +1386,7 @@ def _is_all_day_like_calendar_block(start: datetime, duration_hours: float) -> b
 
 def _starts_at_midnight(start: datetime) -> bool:
     """Return whether a datetime starts exactly at midnight."""
-    return start.timetz().replace(tzinfo=None) == time()
+    return start.timetz().replace(tzinfo=None) == clock_time()
 
 
 def _csv_value(row: dict[str, str], aliases: tuple[str, ...]) -> str | None:
@@ -1353,26 +1428,59 @@ def _is_non_meeting_free_busy(value: object) -> bool:
 def _meetings_dataframe(meetings: list[Meeting] | pl.DataFrame) -> pl.DataFrame:
     """Return normalized meetings as a Polars DataFrame with the reporting schema."""
     if isinstance(meetings, pl.DataFrame):
-        return meetings.select(list(MEETING_FRAME_SCHEMA)).cast(MEETING_FRAME_SCHEMA)
+        return _validate_meetings_frame(meetings.select(list(MEETING_FRAME_SCHEMA)).cast(MEETING_FRAME_SCHEMA))
 
     rows = [
         {
             "start": _meeting_local_start(meeting),
-            "date": meeting["date"],
-            "time": meeting["time"],
-            "summary": meeting["summary"],
-            "duration_hours": float(meeting["duration_hours"]),
+            "date": meeting.date,
+            "time": meeting.time,
+            "summary": meeting.summary,
+            "duration_hours": meeting.duration_hours,
         }
         for meeting in meetings
     ]
     if not rows:
         return pl.DataFrame(schema=MEETING_FRAME_SCHEMA)
-    return pl.DataFrame(rows, schema=MEETING_FRAME_SCHEMA, orient="row")
+    return _validate_meetings_frame(pl.DataFrame(rows, schema=MEETING_FRAME_SCHEMA, orient="row"))
 
 
 def _meeting_local_start(meeting: Meeting) -> datetime:
     """Return a Pacific local naive datetime for cache filtering."""
-    return _local_naive_datetime(meeting["start"])
+    return _local_naive_datetime(meeting.start)
+
+
+def _validate_meetings_frame(frame: pl.DataFrame) -> pl.DataFrame:
+    """Return a normalized meeting frame after validating row invariants."""
+    for index, row in enumerate(frame.iter_rows(named=True), start=1):
+        start = row["start"]
+        meeting_date = row["date"]
+        meeting_time = row["time"]
+        summary = row["summary"]
+        duration_hours = row["duration_hours"]
+
+        if not isinstance(start, datetime):
+            msg = f"meeting row {index} has invalid start: {start!r}"
+            raise TypeError(msg)
+        if not isinstance(meeting_date, calendar_date):
+            msg = f"meeting row {index} has invalid date: {meeting_date!r}"
+            raise TypeError(msg)
+        if not isinstance(meeting_time, clock_time):
+            msg = f"meeting row {index} has invalid time: {meeting_time!r}"
+            raise TypeError(msg)
+        if not isinstance(summary, str) or not summary:
+            msg = f"meeting row {index} has invalid summary: {summary!r}"
+            raise ValueError(msg)
+        if not isinstance(duration_hours, int | float) or not math.isfinite(duration_hours) or duration_hours <= 0:
+            msg = f"meeting row {index} has invalid duration_hours: {duration_hours!r}"
+            raise ValueError(msg)
+        if meeting_date != start.date():
+            msg = f"meeting row {index} date {meeting_date!r} does not match start {start!r}"
+            raise ValueError(msg)
+        if meeting_time != start.time():
+            msg = f"meeting row {index} time {meeting_time!r} does not match start {start!r}"
+            raise ValueError(msg)
+    return frame
 
 
 def _local_naive_datetime(value: datetime) -> datetime:
@@ -1403,13 +1511,22 @@ def _read_meetings_dataframe(dataframe_path: Path) -> pl.DataFrame:
             f"Error reading saved Polars DataFrame: missing columns {sorted(missing_columns)}"
         )
 
-    return _meetings_dataframe(frame)
+    try:
+        return _meetings_dataframe(frame)
+    except (TypeError, ValueError, pl.exceptions.PolarsError) as error:
+        raise SavedDataFrameReadError(f"Error reading saved Polars DataFrame: {error}") from error
 
 
 def _write_meetings_dataframe(frame: pl.DataFrame, dataframe_path: Path, calendar_path: Path) -> None:
     """Write normalized meetings and source metadata to disk."""
     parquet_temp_path: Path | None = None
     metadata_temp_path: Path | None = None
+    parquet_backup_path: Path | None = None
+    metadata_backup_path: Path | None = None
+    parquet_backed_up = False
+    metadata_backed_up = False
+    parquet_replaced = False
+    metadata_replaced = False
     try:
         dataframe_path.parent.mkdir(parents=True, exist_ok=True)
         metadata_path = _cache_metadata_path(dataframe_path)
@@ -1418,15 +1535,39 @@ def _write_meetings_dataframe(frame: pl.DataFrame, dataframe_path: Path, calenda
 
         frame.write_parquet(parquet_temp_path)
         metadata_temp_path.write_text(_cache_metadata(calendar_path, frame), encoding="utf-8")
+
+        if dataframe_path.exists():
+            parquet_backup_path = _temporary_sibling_path(dataframe_path)
+            dataframe_path.replace(parquet_backup_path)
+            parquet_backed_up = True
+        if metadata_path.exists():
+            metadata_backup_path = _temporary_sibling_path(metadata_path)
+            metadata_path.replace(metadata_backup_path)
+            metadata_backed_up = True
+
         parquet_temp_path.replace(dataframe_path)
+        parquet_replaced = True
         parquet_temp_path = None
         metadata_temp_path.replace(metadata_path)
+        metadata_replaced = True
         metadata_temp_path = None
     except (OSError, pl.exceptions.PolarsError) as error:
+        _restore_cache_rewrite_backup(
+            dataframe_path,
+            parquet_backup_path,
+            backed_up=parquet_backed_up,
+            replaced=parquet_replaced,
+        )
+        _restore_cache_rewrite_backup(
+            _cache_metadata_path(dataframe_path),
+            metadata_backup_path,
+            backed_up=metadata_backed_up,
+            replaced=metadata_replaced,
+        )
         print(f"Error saving Polars DataFrame: {error}")
         raise_system_exit()
     finally:
-        for temp_path in (parquet_temp_path, metadata_temp_path):
+        for temp_path in (parquet_temp_path, metadata_temp_path, parquet_backup_path, metadata_backup_path):
             if temp_path is not None and temp_path.exists():
                 temp_path.unlink()
 
@@ -1440,6 +1581,22 @@ def _temporary_sibling_path(destination: Path) -> Path:
     )
     os.close(file_descriptor)
     return Path(temp_name)
+
+
+def _restore_cache_rewrite_backup(
+    destination: Path,
+    backup_path: Path | None,
+    *,
+    backed_up: bool,
+    replaced: bool,
+) -> None:
+    """Restore a cache file that was moved aside during an interrupted rewrite."""
+    if not backed_up and not replaced:
+        return
+    if destination.exists():
+        destination.unlink()
+    if backed_up and backup_path is not None and backup_path.exists():
+        backup_path.replace(destination)
 
 
 def _cache_metadata(calendar_path: Path, frame: pl.DataFrame) -> str:
@@ -1568,11 +1725,11 @@ def _parse_date_argument(value: str | None, label: str, *, end_of_day: bool = Fa
         raise_system_exit()
 
     try:
-        parsed_date = date.fromisoformat(value)
+        parsed_date = calendar_date.fromisoformat(value)
     except ValueError:
         print(f"Error: {label} date must be in YYYY-MM-DD format")
         raise_system_exit()
-    parsed_time = time.max if end_of_day else time.min
+    parsed_time = clock_time.max if end_of_day else clock_time.min
     return datetime.combine(parsed_date, parsed_time, tzinfo=PACIFIC)
 
 

--- a/calendar_analyzer.py
+++ b/calendar_analyzer.py
@@ -91,19 +91,24 @@ class Meeting:
         return convert_to_pacific(self.start).time()
 
     @overload
-    def __getitem__(self, key: Literal["start"]) -> datetime: ...
+    def __getitem__(self, key: Literal["start"]) -> datetime:
+        pass
 
     @overload
-    def __getitem__(self, key: Literal["date"]) -> calendar_date: ...
+    def __getitem__(self, key: Literal["date"]) -> calendar_date:
+        pass
 
     @overload
-    def __getitem__(self, key: Literal["time"]) -> clock_time: ...
+    def __getitem__(self, key: Literal["time"]) -> clock_time:
+        pass
 
     @overload
-    def __getitem__(self, key: Literal["summary"]) -> str: ...
+    def __getitem__(self, key: Literal["summary"]) -> str:
+        pass
 
     @overload
-    def __getitem__(self, key: Literal["duration_hours"]) -> float: ...
+    def __getitem__(self, key: Literal["duration_hours"]) -> float:
+        pass
 
     def __getitem__(
         self,
@@ -376,7 +381,9 @@ def import_calendar_meetings(calendar_path: Path) -> list[Meeting]:
 
     print(f"Error: Unsupported calendar file type: {calendar_path.suffix or '<none>'}")
     print("Supported calendar exports are .icbu, .sqlitedb, .olm, .pst, and explicit Outlook .csv files.")
-    return raise_system_exit()
+    raise_system_exit()
+    msg = "unreachable"
+    raise AssertionError(msg)
 
 
 def _import_sqlite_calendar_meetings(calendar_path: Path) -> list[Meeting]:
@@ -1621,7 +1628,6 @@ def _write_meetings_dataframe(frame: pl.DataFrame, dataframe_path: Path, calenda
     parquet_backed_up = False
     metadata_backed_up = False
     parquet_replaced = False
-    metadata_replaced = False
     try:
         dataframe_path.parent.mkdir(parents=True, exist_ok=True)
         metadata_path = _cache_metadata_path(dataframe_path)
@@ -1644,7 +1650,6 @@ def _write_meetings_dataframe(frame: pl.DataFrame, dataframe_path: Path, calenda
         parquet_replaced = True
         parquet_temp_path = None
         metadata_temp_path.replace(metadata_path)
-        metadata_replaced = True
         metadata_temp_path = None
     except (OSError, pl.exceptions.PolarsError) as error:
         _restore_cache_rewrite_backup(
@@ -1657,7 +1662,7 @@ def _write_meetings_dataframe(frame: pl.DataFrame, dataframe_path: Path, calenda
             _cache_metadata_path(dataframe_path),
             metadata_backup_path,
             backed_up=metadata_backed_up,
-            replaced=metadata_replaced,
+            replaced=False,
         )
         print(f"Error saving Polars DataFrame: {error}")
         raise_system_exit()

--- a/justfile
+++ b/justfile
@@ -134,7 +134,7 @@ python-sync: _ensure-uv
     uv sync --group dev
 
 python-typecheck: _ensure-uv
-    uv run ty check calendar_analyzer.py tests --error all
+    uv run ty check calendar_analyzer.py tests --error all --python-platform all
 
 script-check: shell-check powershell-check
 

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -113,6 +113,39 @@ rules:
       with sqlite3.connect(...) as $CONN:
           ...
 
+  - id: calendar-analyzer.python.no-direct-system-exit
+    languages:
+      - python
+    severity: WARNING
+    message: "Use raise_system_exit() so CLI failures keep a consistent exit status and user-facing path."
+    metadata:
+      category: maintainability
+      rationale: "A single exit helper keeps normal user errors out of traceback-prone or inconsistent control flow."
+    paths:
+      include:
+        - "/calendar_analyzer.py"
+    patterns:
+      - pattern-either:
+          - pattern: raise SystemExit(...)
+          - pattern: sys.exit(...)
+      - pattern-not-inside: |
+          def raise_system_exit(...):
+              ...
+
+  - id: calendar-analyzer.python.no-csv-auto-discovery
+    languages:
+      - python
+    severity: WARNING
+    message: "Do not add CSV files to automatic calendar discovery; CSV is supported only when explicitly requested."
+    metadata:
+      category: privacy
+      rationale: "Generic CSV files are common in Documents and Downloads, so auto-discovering them risks reading unrelated local data."
+    paths:
+      include:
+        - "/calendar_analyzer.py"
+    pattern: |
+      CALENDAR_PATTERNS = (..., "*.csv", ...)
+
   - id: calendar-analyzer.python.no-raw-calendar-record-debug-print
     languages:
       - python

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -146,6 +146,20 @@ rules:
     pattern: |
       CALENDAR_PATTERNS = (..., "*.csv", ...)
 
+  - id: calendar-analyzer.python.no-type-ignore-comments
+    languages:
+      - regex
+    severity: WARNING
+    message: "Avoid mypy-style # type: ignore comments; keep values type-checkable or use a ty-specific suppression."
+    metadata:
+      category: maintainability
+      rationale: "This repository type-checks with ty, so mypy-style ignores are easy to mistake for enforced suppressions."
+    paths:
+      include:
+        - "/calendar_analyzer.py"
+        - "/tests/**/*.py"
+    pattern-regex: '#\s*type:\s*ignore(?:\[[^\]]+\])?'
+
   - id: calendar-analyzer.python.no-raw-calendar-record-debug-print
     languages:
       - python

--- a/tests/test_calendar_analyzer.py
+++ b/tests/test_calendar_analyzer.py
@@ -902,6 +902,20 @@ def test_load_calendar_dataframe_tracks_icbu_sqlite_metadata(capsys, tmp_path: P
     assert f"Found SQLite database in ICBU backup: {sqlite_path}" in capsys.readouterr().out
 
 
+def test_user_cache_directory_uses_windows_locations(monkeypatch, tmp_path: Path) -> None:
+    """Test Windows cache paths prefer LOCALAPPDATA and fall back to the user profile."""
+    local_app_data = tmp_path / "LocalAppData"
+    home = tmp_path / "home"
+    monkeypatch.setattr(calendar_analyzer.sys, "platform", "win32")
+    monkeypatch.setattr(calendar_analyzer.Path, "home", lambda: home)
+
+    monkeypatch.setenv("LOCALAPPDATA", str(local_app_data))
+    assert calendar_analyzer._user_cache_directory() == local_app_data / "calendar-analyzer"  # noqa: SLF001
+
+    monkeypatch.delenv("LOCALAPPDATA")
+    assert calendar_analyzer._user_cache_directory() == home / "AppData" / "Local" / "calendar-analyzer"  # noqa: SLF001
+
+
 def test_main_reimports_when_saved_dataframe_is_corrupt(monkeypatch, capsys, tmp_path: Path) -> None:
     """Test a corrupt saved DataFrame is rebuilt when the calendar source is available."""
     calendar_path = Path(
@@ -1271,6 +1285,20 @@ def test_load_calendar_dataframe_rebuilds_bad_or_stale_metadata(capsys, tmp_path
     assert calendar_analyzer.load_calendar_dataframe(calendar_path, dataframe_path).is_empty()
     assert f"Saved Polars DataFrame is stale or from another calendar: {dataframe_path}" in capsys.readouterr().out
 
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "schema_version": str(calendar_analyzer.CACHE_SCHEMA_VERSION),
+                "source_path": str(calendar_path.resolve()),
+                "source_mtime_ns": calendar_path.stat().st_mtime_ns,
+                "source_size": calendar_path.stat().st_size,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert calendar_analyzer.load_calendar_dataframe(calendar_path, dataframe_path).is_empty()
+    assert f"Saved Polars DataFrame is stale or from another calendar: {dataframe_path}" in capsys.readouterr().out
+
     source_stat = calendar_path.stat()
     metadata_path.write_text(
         json.dumps(
@@ -1305,6 +1333,84 @@ def test_cache_metadata_handles_unstatable_calendar_source(monkeypatch, tmp_path
     assert metadata["source_path"] == str(calendar_path.resolve())
     assert metadata["source_mtime_ns"] is None
     assert metadata["source_size"] is None
+
+
+def test_cached_dataframe_is_unusable_when_calendar_source_cannot_resolve(monkeypatch, tmp_path: Path) -> None:
+    """Test unreadable requested calendar paths make a saved cache unusable."""
+    dataframe_path = tmp_path / "meetings.parquet"
+    dataframe_path.write_bytes(b"parquet placeholder")
+    dataframe_path.with_suffix(f"{dataframe_path.suffix}.metadata.json").write_text(
+        json.dumps(
+            {
+                "schema_version": calendar_analyzer.CACHE_SCHEMA_VERSION,
+                "source_path": str(tmp_path / "calendar.sqlitedb"),
+                "source_mtime_ns": None,
+                "source_size": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def raise_source_error(_calendar_path: Path) -> NoReturn:
+        message = "unreadable"
+        raise OSError(message)
+
+    monkeypatch.setattr("calendar_analyzer._resolve_calendar_source_path", raise_source_error)
+
+    assert not calendar_analyzer._cached_dataframe_is_usable(dataframe_path, tmp_path / "calendar.sqlitedb")  # noqa: SLF001
+
+
+def test_metadata_matches_calendar_handles_unresolvable_calendar_source(monkeypatch, tmp_path: Path) -> None:
+    """Test metadata comparison rejects paths that cannot be resolved."""
+    calendar_path = tmp_path / "calendar.sqlitedb"
+    metadata = calendar_analyzer.CacheMetadata(
+        schema_version=calendar_analyzer.CACHE_SCHEMA_VERSION,
+        source_path=str(calendar_path),
+        source_mtime_ns=None,
+        source_size=None,
+    )
+
+    def raise_source_error(_calendar_path: Path) -> NoReturn:
+        message = "unreadable"
+        raise OSError(message)
+
+    monkeypatch.setattr("calendar_analyzer._resolve_calendar_source_path", raise_source_error)
+
+    assert not calendar_analyzer._metadata_matches_calendar(metadata, calendar_path)  # noqa: SLF001
+
+
+def test_metadata_matches_calendar_handles_unstatable_resolved_source(monkeypatch, tmp_path: Path) -> None:
+    """Test metadata comparison rejects matching paths when stat fails."""
+
+    class UnstatablePath:
+        """Path-like test double that cannot be statted."""
+
+        def __str__(self) -> str:
+            return "/calendar.sqlitedb"
+
+        def stat(self) -> object:
+            message = "unstatable"
+            raise OSError(message)
+
+    unstatable_path = UnstatablePath()
+    monkeypatch.setattr("calendar_analyzer._resolve_calendar_source_path", lambda _path: unstatable_path)
+    metadata = calendar_analyzer.CacheMetadata(
+        schema_version=calendar_analyzer.CACHE_SCHEMA_VERSION,
+        source_path=str(unstatable_path),
+        source_mtime_ns=None,
+        source_size=None,
+    )
+
+    assert not calendar_analyzer._metadata_matches_calendar(metadata, tmp_path / "calendar.sqlitedb")  # noqa: SLF001
+
+
+def test_date_range_overlap_accepts_unknown_data_bounds() -> None:
+    """Test cache prompt range checks accept saved data without coverage bounds."""
+    period_start = datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC)
+    period_end = datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC)
+
+    assert calendar_analyzer._date_range_overlaps_data(period_start, period_end, None, period_start.date())  # noqa: SLF001
+    assert calendar_analyzer._date_range_overlaps_data(period_start, period_end, period_start.date(), None)  # noqa: SLF001
 
 
 def test_main_supports_text_only_stdout(monkeypatch) -> None:
@@ -1551,6 +1657,91 @@ def test_summary_options_reject_invalid_invariants(options: dict[str, Any], mess
 
 
 @pytest.mark.parametrize(
+    ("kwargs", "expected_error", "message"),
+    [
+        ({"schema_version": True}, TypeError, "schema_version must be an integer"),
+        ({"source_path": ""}, ValueError, "source_path must be a non-empty string"),
+        ({"source_mtime_ns": "soon"}, TypeError, "source_mtime_ns must be an integer or null"),
+        ({"source_size": "large"}, TypeError, "source_size must be an integer or null"),
+        ({"data_start": "2023-07-01"}, TypeError, "data_start must be a date or null"),
+        ({"data_end": "2023-07-02"}, TypeError, "data_end must be a date or null"),
+        (
+            {
+                "data_start": datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC).date(),
+                "data_end": datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC).date(),
+            },
+            ValueError,
+            "data_end cannot be before data_start",
+        ),
+    ],
+)
+def test_cache_metadata_rejects_invalid_invariants(
+    kwargs: dict[str, Any],
+    expected_error: type[Exception],
+    message: str,
+) -> None:
+    """Test parsed cache metadata cannot store invalid sidecar values."""
+    values: dict[str, Any] = {
+        "schema_version": calendar_analyzer.CACHE_SCHEMA_VERSION,
+        "source_path": "/calendar.sqlitedb",
+        "source_mtime_ns": None,
+        "source_size": None,
+    }
+    values.update(kwargs)
+
+    with pytest.raises(expected_error, match=message):
+        calendar_analyzer.CacheMetadata(**values)
+
+
+@pytest.mark.parametrize(
+    ("raw_metadata", "expected_error", "message"),
+    [
+        ([], TypeError, "cache metadata must be a JSON object"),
+        (
+            {
+                "schema_version": "1",
+                "source_path": "/calendar.sqlitedb",
+                "source_mtime_ns": None,
+                "source_size": None,
+            },
+            TypeError,
+            "schema_version must be an integer",
+        ),
+        (
+            {
+                "schema_version": 1,
+                "source_path": "/calendar.sqlitedb",
+                "source_mtime_ns": None,
+                "source_size": None,
+                "data_start": 20230701,
+            },
+            TypeError,
+            "data_start must be an ISO date string or null",
+        ),
+        (
+            {
+                "schema_version": 1,
+                "source_path": "/calendar.sqlitedb",
+                "source_mtime_ns": None,
+                "source_size": None,
+                "data_start": "not-a-date",
+            },
+            ValueError,
+            "data_start must be an ISO date string",
+        ),
+    ],
+)
+def test_cache_metadata_from_raw_rejects_malformed_fields(
+    raw_metadata: object,
+    expected_error: type[Exception],
+    message: str,
+) -> None:
+    """Test raw JSON cache metadata is parsed before use."""
+    with pytest.raises(expected_error, match=message):
+        calendar_analyzer.CacheMetadata.from_raw(raw_metadata)
+
+
+@pytest.mark.parametrize(
     ("kwargs", "message"),
     [
         (
@@ -1574,6 +1765,57 @@ def test_meeting_rejects_invalid_invariants(kwargs: dict[str, Any], message: str
             start=datetime(2023, 7, 1, 10, 0, tzinfo=calendar_analyzer.PACIFIC),
             **kwargs,
         )
+
+
+def test_meeting_rejects_invalid_start_type() -> None:
+    """Test meeting start must already be parsed into a datetime."""
+    invalid_start: Any = "2023-07-01"
+    with pytest.raises(TypeError, match="Meeting start must be a datetime"):
+        calendar_analyzer.Meeting(start=invalid_start, summary="Bad Start", duration_hours=1.0)
+
+
+def test_meeting_supports_legacy_mapping_access() -> None:
+    """Test validated meetings keep the old mapping-style read contract."""
+    start = datetime(2023, 7, 1, 17, 0, tzinfo=UTC)
+    meeting = calendar_analyzer.Meeting(start=start, summary="Planning", duration_hours=1.5)
+
+    assert meeting["start"] == start
+    assert meeting["date"] == datetime(2023, 7, 1, 10, 0, tzinfo=calendar_analyzer.PACIFIC).date()
+    assert meeting["time"] == datetime(2023, 7, 1, 10, 0, tzinfo=calendar_analyzer.PACIFIC).time()
+    assert meeting["summary"] == "Planning"
+    assert meeting["duration_hours"] == 1.5
+    unknown_key: Any = "unknown"
+    with pytest.raises(KeyError):
+        meeting[unknown_key]
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "expected_error", "message"),
+    [
+        ("start", "2023-07-01T10:00:00", TypeError, "invalid start"),
+        ("date", "2023-07-01", TypeError, "invalid date"),
+        ("time", "10:00:00", TypeError, "invalid time"),
+    ],
+)
+def test_validate_meetings_frame_rejects_unparsed_temporal_fields(
+    field_name: str,
+    value: object,
+    expected_error: type[Exception],
+    message: str,
+) -> None:
+    """Test normalized frames reject temporal fields that were not parsed."""
+    start = datetime(2023, 7, 1, 10, 0, tzinfo=UTC)
+    row: dict[str, object] = {
+        "start": start,
+        "date": start.date(),
+        "time": start.time(),
+        "summary": "Planning",
+        "duration_hours": 1.0,
+    }
+    row[field_name] = value
+
+    with pytest.raises(expected_error, match=message):
+        calendar_analyzer._validate_meetings_frame(pl.DataFrame([row], orient="row"))  # noqa: SLF001
 
 
 def test_analyze_calendar_date_filtering() -> None:
@@ -2285,6 +2527,30 @@ def test_analyze_calendar_errors_when_olm_split_start_time_invalid(capsys) -> No
     assert "not-a-time" in out
 
 
+def test_analyze_calendar_errors_when_olm_iso_start_invalid(capsys) -> None:
+    """Test malformed combined OLM ISO datetimes are reported as parse errors."""
+    calendar_xml = textwrap.dedent("""
+    <appointments>
+      <appointment>
+        <OPFCalendarEventCopySummary>Broken ISO Date</OPFCalendarEventCopySummary>
+        <OPFCalendarEventCopyStartTime>2023-13-01T10:00:00</OPFCalendarEventCopyStartTime>
+      </appointment>
+    </appointments>
+    """)
+    tmp_path = create_temp_olm_file(calendar_xml)
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            calendar_analyzer.analyze_calendar(Path(tmp_path))
+    finally:
+        Path(tmp_path).unlink()
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error parsing OLM calendar: Could not parse any OLM appointment start dates." in out
+    assert "2023-13-01T10:00:00" in out
+
+
 def test_analyze_calendar_with_explicit_outlook_csv_file() -> None:
     """Test explicit Outlook CSV calendar analysis remains supported."""
     with tempfile.NamedTemporaryFile(suffix=".csv", mode="w", encoding="utf-8", newline="", delete=False) as tmp:
@@ -2389,6 +2655,25 @@ def test_analyze_calendar_outlook_csv_errors_when_combined_start_does_not_parse(
     out = capsys.readouterr().out
     assert "Error parsing Outlook CSV calendar: Could not parse any Outlook CSV start dates." in out
     assert "not-a-date 10:00 AM" in out
+
+
+def test_outlook_csv_start_datetime_skips_non_meeting_rows() -> None:
+    """Test CSV start parsing skips rows that Outlook marks as all-day blocks."""
+    row = {
+        "Subject": "All Day",
+        "Start Date": "07/01/2023",
+        "Start Time": "10:00 AM",
+        "All day event": "True",
+    }
+
+    assert calendar_analyzer._outlook_csv_start_datetime(row) is None  # noqa: SLF001
+
+
+def test_outlook_csv_start_diagnostics_reports_lone_start_time() -> None:
+    """Test CSV parse diagnostics include orphaned time fields."""
+    row = {"Start Time": "10:00 AM"}
+
+    assert calendar_analyzer._outlook_csv_start_value_for_diagnostics(row) == "10:00 AM"  # noqa: SLF001
 
 
 def test_analyze_calendar_filters_requested_outlook_csv_range(tmp_path: Path) -> None:
@@ -2513,6 +2798,34 @@ def test_analyze_calendar_outlook_csv_defaults_malformed_split_end(tmp_path: Pat
     assert [meeting["summary"] for meeting in meetings] == ["Default End"]
 
 
+def test_outlook_datetime_accepts_date_only_when_time_is_optional() -> None:
+    """Test Outlook date parsing accepts date-only values outside timed start fields."""
+    assert calendar_analyzer._outlook_datetime("2023-07-01") == datetime(  # noqa: SLF001
+        2023,
+        7,
+        1,
+        tzinfo=calendar_analyzer.PACIFIC,
+    )
+
+
+def test_parse_outlook_iso_datetime_assumes_naive_values_are_pacific() -> None:
+    """Test ISO fallback parsing keeps naive Outlook timestamps in Pacific time."""
+    assert calendar_analyzer._parse_outlook_iso_datetime("2023-07-01T10:30") == datetime(  # noqa: SLF001
+        2023,
+        7,
+        1,
+        10,
+        30,
+        tzinfo=calendar_analyzer.PACIFIC,
+    )
+
+
+def test_fallback_date_text_requires_a_date() -> None:
+    """Test fallback date conversion is only called after a date exists."""
+    with pytest.raises(ValueError, match="Fallback date is required"):
+        calendar_analyzer._fallback_date_text(None)  # noqa: SLF001
+
+
 def test_analyze_calendar_defaults_missing_sqlite_summary() -> None:
     """Test SQLite rows use the default title when summary is empty."""
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2595,6 +2908,14 @@ def test_analyze_calendar_icbu_no_calendar_data(capsys) -> None:
         assert "Contents of ICBU directory:" in out
         assert "other_file.txt" in out
         assert "metadata.plist" in out
+
+
+def test_resolve_calendar_source_path_keeps_icbu_without_sqlite(tmp_path: Path) -> None:
+    """Test cache metadata can still refer to an ICBU directory before import validates it."""
+    icbu_path = tmp_path / "backup.icbu"
+    icbu_path.mkdir()
+
+    assert calendar_analyzer._resolve_calendar_source_path(icbu_path) == icbu_path.resolve()  # noqa: SLF001
 
 
 def test_analyze_calendar_icbu_directory_listing_error(capsys) -> None:

--- a/tests/test_calendar_analyzer.py
+++ b/tests/test_calendar_analyzer.py
@@ -1027,6 +1027,125 @@ def test_main_exits_for_saved_dataframe_missing_columns(monkeypatch, capsys, tmp
     assert "No calendar files found" not in out
 
 
+def test_main_exits_for_saved_dataframe_with_inconsistent_meeting_row(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+) -> None:
+    """Test cache-only runs reject rows whose derived meeting fields disagree."""
+    calendar_path = Path(
+        create_temp_sqlite_calendar(
+            [
+                (
+                    "Cached Meeting",
+                    datetime(2023, 7, 1, 17, 0, tzinfo=UTC),
+                    datetime(2023, 7, 1, 18, 0, tzinfo=UTC),
+                    0,
+                )
+            ]
+        )
+    )
+    dataframe_path = tmp_path / "meetings.parquet"
+    calendar_analyzer.load_calendar_dataframe(calendar_path, dataframe_path, force_import=True)
+    pl.read_parquet(dataframe_path).with_columns(
+        pl.lit(datetime(2023, 7, 2, tzinfo=UTC).date()).cast(pl.Date).alias("date")
+    ).write_parquet(dataframe_path)
+    capsys.readouterr()
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "calendar-analyzer",
+            "--dataframe",
+            str(dataframe_path),
+            "--start-date",
+            "2023-06-30",
+            "--end-date",
+            "2023-07-03",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.main()
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error reading saved Polars DataFrame: meeting row 1 date" in out
+    assert "does not match start" in out
+    assert "No calendar files found" not in out
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda frame: frame.with_columns(pl.lit("").alias("summary")),
+            "invalid summary: ''",
+        ),
+        (
+            lambda frame: frame.with_columns(pl.lit(0.0).alias("duration_hours")),
+            "invalid duration_hours: 0.0",
+        ),
+        (
+            lambda frame: frame.with_columns(pl.lit(float("nan")).alias("duration_hours")),
+            "invalid duration_hours: nan",
+        ),
+        (
+            lambda frame: frame.with_columns(
+                pl.lit(datetime(2023, 7, 1, 11, 0, tzinfo=UTC).time()).cast(pl.Time).alias("time")
+            ),
+            "time datetime.time(11, 0) does not match start",
+        ),
+    ],
+)
+def test_main_exits_for_saved_dataframe_with_invalid_meeting_values(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+    mutation,
+    message: str,
+) -> None:
+    """Test cache-only runs reject invalid row values beyond schema shape."""
+    calendar_path = Path(
+        create_temp_sqlite_calendar(
+            [
+                (
+                    "Cached Meeting",
+                    datetime(2023, 7, 1, 17, 0, tzinfo=UTC),
+                    datetime(2023, 7, 1, 18, 0, tzinfo=UTC),
+                    0,
+                )
+            ]
+        )
+    )
+    dataframe_path = tmp_path / "meetings.parquet"
+    calendar_analyzer.load_calendar_dataframe(calendar_path, dataframe_path, force_import=True)
+    mutation(pl.read_parquet(dataframe_path)).write_parquet(dataframe_path)
+    capsys.readouterr()
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "calendar-analyzer",
+            "--dataframe",
+            str(dataframe_path),
+            "--start-date",
+            "2023-06-30",
+            "--end-date",
+            "2023-07-03",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.main()
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error reading saved Polars DataFrame: meeting row 1" in out
+    assert message in out
+    assert "No calendar files found" not in out
+
+
 def test_write_meetings_dataframe_preserves_existing_cache_on_failure(monkeypatch, capsys, tmp_path: Path) -> None:
     """Test failed cache rewrites keep the previous readable DataFrame."""
     calendar_path = tmp_path / "calendar.sqlitedb"
@@ -1071,6 +1190,69 @@ def test_write_meetings_dataframe_preserves_existing_cache_on_failure(monkeypatc
     assert "Error saving Polars DataFrame: simulated metadata failure" in capsys.readouterr().out
     rows = list(pl.read_parquet(dataframe_path).iter_rows(named=True))
     assert [row["summary"] for row in rows] == ["Original Cache"]
+
+
+def test_write_meetings_dataframe_restores_cache_when_metadata_replace_fails(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+) -> None:
+    """Test cache rewrites restore old files if sidecar replacement fails."""
+    calendar_path = tmp_path / "calendar.sqlitedb"
+    dataframe_path = tmp_path / "meetings.parquet"
+    metadata_path = dataframe_path.with_suffix(f"{dataframe_path.suffix}.metadata.json")
+    Path(
+        create_temp_sqlite_calendar(
+            [
+                (
+                    "Original Cache",
+                    datetime(2023, 7, 1, 17, 0, tzinfo=UTC),
+                    datetime(2023, 7, 1, 18, 0, tzinfo=UTC),
+                    0,
+                )
+            ]
+        )
+    ).replace(calendar_path)
+    calendar_analyzer.load_calendar_dataframe(calendar_path, dataframe_path, force_import=True)
+    original_metadata = metadata_path.read_text(encoding="utf-8")
+    calendar_path.unlink()
+    Path(
+        create_temp_sqlite_calendar(
+            [
+                (
+                    "Replacement Cache",
+                    datetime(2023, 7, 2, 17, 0, tzinfo=UTC),
+                    datetime(2023, 7, 2, 19, 0, tzinfo=UTC),
+                    0,
+                )
+            ]
+        )
+    ).replace(calendar_path)
+    real_replace = Path.replace
+    failed_metadata_replace = False
+
+    def fail_metadata_replace(self: Path, target: str | Path) -> Path:
+        nonlocal failed_metadata_replace
+        if (
+            not failed_metadata_replace
+            and self.name.startswith(f".{metadata_path.name}.")
+            and Path(target) == metadata_path
+        ):
+            failed_metadata_replace = True
+            message = "simulated metadata replace failure"
+            raise OSError(message)
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", fail_metadata_replace)
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.load_calendar_dataframe(calendar_path, dataframe_path, force_import=True)
+
+    assert exc_info.value.code == 1
+    assert "Error saving Polars DataFrame: simulated metadata replace failure" in capsys.readouterr().out
+    rows = list(pl.read_parquet(dataframe_path).iter_rows(named=True))
+    assert [row["summary"] for row in rows] == ["Original Cache"]
+    assert metadata_path.read_text(encoding="utf-8") == original_metadata
 
 
 def test_load_calendar_dataframe_rebuilds_bad_or_stale_metadata(capsys, tmp_path: Path) -> None:
@@ -1339,6 +1521,59 @@ def test_generate_summary_shows_imported_coverage_and_query_range() -> None:
     assert "Query Date Range:" in result
     assert "- From: July 01, 2023" in result
     assert "- To:   July 31, 2023" in result
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    [
+        ({"num_titles": 0}, "num_titles must be positive"),
+        ({"num_times": 0}, "num_times must be positive"),
+        (
+            {
+                "period_start": datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC),
+                "period_end": datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC),
+            },
+            "period_end cannot be before period_start",
+        ),
+        (
+            {
+                "data_start": datetime(2023, 7, 2, tzinfo=calendar_analyzer.PACIFIC).date(),
+                "data_end": datetime(2023, 7, 1, tzinfo=calendar_analyzer.PACIFIC).date(),
+            },
+            "data_end cannot be before data_start",
+        ),
+    ],
+)
+def test_summary_options_reject_invalid_invariants(options: dict[str, Any], message: str) -> None:
+    """Test summary display options carry validated invariants."""
+    with pytest.raises(ValueError, match=message):
+        calendar_analyzer.SummaryOptions(**options)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {"summary": "", "duration_hours": 1.0},
+            "Meeting summary must be a non-empty string",
+        ),
+        (
+            {"summary": "Bad Duration", "duration_hours": 0.0},
+            "Meeting duration_hours must be positive and finite",
+        ),
+        (
+            {"summary": "Bad Duration", "duration_hours": float("nan")},
+            "Meeting duration_hours must be positive and finite",
+        ),
+    ],
+)
+def test_meeting_rejects_invalid_invariants(kwargs: dict[str, Any], message: str) -> None:
+    """Test validated meeting objects cannot store invalid domain values."""
+    with pytest.raises(ValueError, match=message):
+        calendar_analyzer.Meeting(
+            start=datetime(2023, 7, 1, 10, 0, tzinfo=calendar_analyzer.PACIFIC),
+            **kwargs,
+        )
 
 
 def test_analyze_calendar_date_filtering() -> None:
@@ -2305,6 +2540,27 @@ def test_analyze_calendar_defaults_missing_sqlite_summary() -> None:
 
         assert stats == {"total_meetings": 1, "total_hours": 1.0}
         assert meetings[0]["summary"] == "No Title"
+
+
+def test_analyze_calendar_sqlite_reports_malformed_date_rows(capsys, tmp_path: Path) -> None:
+    """Test malformed Apple SQLite date fields produce a user-facing parse error."""
+    sqlite_path = tmp_path / "calendar.sqlitedb"
+    with closing(sqlite3.connect(sqlite_path)) as conn:
+        conn.execute("CREATE TABLE CalendarItem (summary TEXT, start_date INTEGER, end_date INTEGER)")
+        conn.execute(
+            "INSERT INTO CalendarItem (summary, start_date, end_date) VALUES (?, ?, ?)",
+            ("Broken Date Meeting", None, 1),
+        )
+        conn.commit()
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_analyzer.analyze_calendar(sqlite_path)
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Error parsing SQLite calendar:" in out
+    assert "Broken Date Meeting" in out
+    assert "invalid start_date: None" in out
 
 
 def test_analyze_calendar_sqlite_read_error(capsys) -> None:

--- a/tests/test_calendar_analyzer.py
+++ b/tests/test_calendar_analyzer.py
@@ -1786,7 +1786,7 @@ def test_meeting_supports_legacy_mapping_access() -> None:
     assert meeting["duration_hours"] == 1.5
     unknown_key: Any = "unknown"
     with pytest.raises(KeyError):
-        meeting[unknown_key]
+        _ = meeting[unknown_key]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Validate imported meetings as invariant-bearing domain objects before reporting
- Reject malformed SQLite date fields with user-facing parse errors
- Reject saved Parquet caches whose derived date or time fields disagree with starts
- Restore existing cache files if metadata replacement fails during refresh
- Add project Semgrep rules for CLI exit handling and explicit-only CSV imports